### PR TITLE
Minimum ratio + Delete data with torrent

### DIFF
--- a/seedtime/core.py
+++ b/seedtime/core.py
@@ -49,6 +49,7 @@ CONFIG_DEFAULT = {
     "default_stop_time": 7,
     "apply_stop_time": False,
     "remove_torrent": False,
+    "remove_data": False,
     "apply_stop_ratio": False,
     "minimum_stop_ratio": 1.0,
     "torrent_stop_times":{} # torrent_id: stop_time (in hours)
@@ -106,7 +107,7 @@ class Core(CorePluginBase):
             if (torrent_status['seeding_time'] > stop_time * 3600.0 * 24.0
                 and torrent_ratio >= stop_ratio):
                 if self.config['remove_torrent']:
-                    self.torrent_manager.remove(torrent.torrent_id)
+                    self.torrent_manager.remove(torrent.torrent_id, self.config["remove_data"])
                 else:
                     torrent.pause()
 

--- a/seedtime/core.py
+++ b/seedtime/core.py
@@ -49,6 +49,8 @@ CONFIG_DEFAULT = {
     "default_stop_time": 7,
     "apply_stop_time": False,
     "remove_torrent": False,
+    "apply_stop_ratio": False,
+    "minimum_stop_ratio": 1.0,
     "torrent_stop_times":{} # torrent_id: stop_time (in hours)
 }
 
@@ -88,7 +90,21 @@ class Core(CorePluginBase):
             if not (torrent.state == "Seeding" and torrent.torrent_id in self.torrent_stop_times):
                 continue
             stop_time = self.torrent_stop_times[torrent.torrent_id]
-            if torrent.get_status(['seeding_time'])['seeding_time'] > stop_time * 3600.0 * 24.0:
+            # if the "minimum ratio" functionnality is not activated, set a negative minimum ratio.
+            if self.config["apply_stop_ratio"]:
+                stop_ratio = self.config["minimum_stop_ratio"]
+            else:
+                stop_ratio = -1.0
+            
+            # same ratio calculation method as Deluge's torrent.py:get_ratio()
+            torrent_status = torrent.get_status(['seeding_time', 'total_uploaded', 'total_done'])
+            if torrent_status['total_done'] > 0:
+                torrent_ratio = float(torrent_status['total_uploaded']) / float(torrent_status['total_done'])
+            else:
+                torrent_ratio = -1.0
+
+            if (torrent_status['seeding_time'] > stop_time * 3600.0 * 24.0
+                and torrent_ratio >= stop_ratio):
                 if self.config['remove_torrent']:
                     self.torrent_manager.remove(torrent.torrent_id)
                 else:

--- a/seedtime/core.py
+++ b/seedtime/core.py
@@ -91,21 +91,12 @@ class Core(CorePluginBase):
             if not (torrent.state == "Seeding" and torrent.torrent_id in self.torrent_stop_times):
                 continue
             stop_time = self.torrent_stop_times[torrent.torrent_id]
-            # if the "minimum ratio" functionnality is not activated, set a negative minimum ratio.
-            if self.config["apply_stop_ratio"]:
-                stop_ratio = self.config["minimum_stop_ratio"]
-            else:
-                stop_ratio = -1.0
-            
-            # same ratio calculation method as Deluge's torrent.py:get_ratio()
-            torrent_status = torrent.get_status(['seeding_time', 'total_uploaded', 'total_done'])
-            if torrent_status['total_done'] > 0:
-                torrent_ratio = float(torrent_status['total_uploaded']) / float(torrent_status['total_done'])
-            else:
-                torrent_ratio = -1.0
+            stop_ratio = self.config["minimum_stop_ratio"]
+
+            torrent_status = torrent.get_status(['seeding_time', 'ratio'])
 
             if (torrent_status['seeding_time'] > stop_time * 3600.0 * 24.0
-                and torrent_ratio >= stop_ratio):
+                and (not self.config["apply_stop_ratio"] or torrent_status['ratio'] >= stop_ratio) ):
                 if self.config['remove_torrent']:
                     self.torrent_manager.remove(torrent.torrent_id, self.config["remove_data"])
                 else:

--- a/seedtime/data/config.glade
+++ b/seedtime/data/config.glade
@@ -179,6 +179,63 @@
           </packing>
         </child>
         <child>
+          <widget class="GtkHBox" id="hbox2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <widget class="GtkCheckButton" id="chk_apply_stop_ratio">
+                <property name="label" translatable="yes">Minimum ratio to reach before stopping</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="draw_indicator">True</property>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkEntry" id="txt_minimum_stop_ratio">
+                <property name="width_request">50</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="invisible_char">●</property>
+                <property name="primary_icon_activatable">False</property>
+                <property name="secondary_icon_activatable">False</property>
+                <property name="primary_icon_sensitive">True</property>
+                <property name="secondary_icon_sensitive">True</property>
+                <signal name="editing_done" handler="on_edit_done" swapped="no"/>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">5</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkLabel" id="label4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">  (applies to all torrents)</property>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </widget>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="padding">3</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
           <widget class="GtkCheckButton" id="chk_remove_torrent">
             <property name="label" translatable="yes">Remove torrent when stopping</property>
             <property name="visible">True</property>
@@ -191,7 +248,7 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="padding">3</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -203,7 +260,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </widget>

--- a/seedtime/data/config.glade
+++ b/seedtime/data/config.glade
@@ -252,6 +252,22 @@
           </packing>
         </child>
         <child>
+          <widget class="GtkCheckButton" id="chk_remove_data">
+            <property name="label" translatable="yes">Remove downloaded data when removing a torrent</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="xalign">0.50999999046325684</property>
+            <property name="draw_indicator">True</property>
+          </widget>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="padding">3</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
           <widget class="GtkLabel" id="lbl_error">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -260,7 +276,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </widget>

--- a/seedtime/gtkui.py
+++ b/seedtime/gtkui.py
@@ -94,6 +94,7 @@ class GtkUI(GtkPluginBase):
             "apply_stop_time": self.glade.get_widget("chk_apply_stop_time").get_active(),
             "apply_stop_ratio": self.glade.get_widget("chk_apply_stop_ratio").get_active(),
             "remove_torrent": self.glade.get_widget("chk_remove_torrent").get_active(),
+            "remove_data": self.glade.get_widget("chk_remove_data").get_active(),
             "default_stop_time": stop_time,
             "minimum_stop_ratio": stop_ratio
         }
@@ -109,6 +110,7 @@ class GtkUI(GtkPluginBase):
         self.glade.get_widget("chk_apply_stop_time").set_active(config["apply_stop_time"])
         self.glade.get_widget("chk_apply_stop_ratio").set_active(config["apply_stop_ratio"])
         self.glade.get_widget("chk_remove_torrent").set_active(config["remove_torrent"])
+        self.glade.get_widget("chk_remove_data").set_active(config["remove_data"])
         self.glade.get_widget("txt_default_stop_time").set_text('%.02f' % config["default_stop_time"])
         self.glade.get_widget("txt_minimum_stop_ratio").set_text('%.02f' % config["minimum_stop_ratio"])
 

--- a/seedtime/gtkui.py
+++ b/seedtime/gtkui.py
@@ -84,6 +84,7 @@ class GtkUI(GtkPluginBase):
 
         try:
             stop_time = float(self.glade.get_widget("txt_default_stop_time").get_text())
+            stop_ratio = float(self.glade.get_widget("txt_minimum_stop_ratio").get_text())
         except ValueError:
             self.glade.get_widget("lbl_error").set_text('You must enter a valid number!')
             return False
@@ -91,8 +92,10 @@ class GtkUI(GtkPluginBase):
         self.glade.get_widget("lbl_error").set_text("")
         config = {
             "apply_stop_time": self.glade.get_widget("chk_apply_stop_time").get_active(),
+            "apply_stop_ratio": self.glade.get_widget("chk_apply_stop_ratio").get_active(),
             "remove_torrent": self.glade.get_widget("chk_remove_torrent").get_active(),
-            "default_stop_time": stop_time
+            "default_stop_time": stop_time,
+            "minimum_stop_ratio": stop_ratio
         }
         client.seedtime.set_config(config)
 
@@ -104,8 +107,10 @@ class GtkUI(GtkPluginBase):
         """callback for on show_prefs"""
         log.debug('cb get config seedtime')
         self.glade.get_widget("chk_apply_stop_time").set_active(config["apply_stop_time"])
+        self.glade.get_widget("chk_apply_stop_ratio").set_active(config["apply_stop_ratio"])
         self.glade.get_widget("chk_remove_torrent").set_active(config["remove_torrent"])
         self.glade.get_widget("txt_default_stop_time").set_text('%.02f' % config["default_stop_time"])
+        self.glade.get_widget("txt_minimum_stop_ratio").set_text('%.02f' % config["minimum_stop_ratio"])
 
 class SeedTimeMenu(gtk.MenuItem):
     def __init__(self):


### PR DESCRIPTION
I have added two functionnalities which I think could be usefull to others:
- only stop if a ratio is reached: allows to set up a minimum ratio value so that the upload stops only if both the seedtime and the ratio are reached
- delete downloaded data when deleting torrent: a new option allowing to make the plugin delete the downloaded data when it deletes a torrent.
