### PR TITLE
Initial seedtime limit based on tracker or label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+env/
+*.code-workspace
+build/
+dist/
+*egg-info/
+.eggs/
+*.pyc
+create_dev_link.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# deluge-seedtime
+Deluge plugin to stop torrents after seeding for a certain amount of time.
+
+# Build instructions
+1. Clone the repo
+1. From the command line, navagate to repo directory
+1. Run command `python setup.py bdist_egg`
+  * note: If your default python version is different from the deluge python version (2.7), then you will have to change `python` to reference the correct binary.
+1. check the `dist` folder, you should see a `SeedTime*.egg`, this is file to choose when installing the plugin from deluge
+
+# Install instructions
+1. Open Deluge
+1. Open Preferences
+1. Select `Plugings` from the Categories on the left
+1. Press the `Install Plugin` button
+![Installing SeedTime](https://cloud.githubusercontent.com/assets/8310169/14019965/7dcf179e-f1ab-11e5-93be-c9550559e351.png)
+1. Choose the SeedTime*.egg plugin file
+1. Check the box in front of the SeedTime plugin to enable it
+![Enabling SeedTime](https://cloud.githubusercontent.com/assets/8310169/14019962/7c1462c4-f1ab-11e5-812f-5e43b6b333ac.png)
+
+# Using the plugin
+1. Select SeedTime from the Categories on the left
+1. Setup filters
+  1. Press `Add` to create a new filter
+  1. Press the cell in the `Field` column on the row of the new filter, select label or tracker depending on what you want to filter on.
+    * Note: The Label plugin needs to be enabled for any label filters in SeedTime to have an effect
+  1. Change the `Filter` cell to appropriate RegEx
+  1. Set the `Stop Seed Time` as a number or days
+  ![Image of Yaktocat](https://cloud.githubusercontent.com/assets/8310169/14019957/7a73b6b8-f1ab-11e5-9dc5-7be69f1f5cb7.png)
+  1. Add/Remove more filters as you want. Filters are evaluated from top to bottom, press the up and down buttons rearrange the list.
+  1. Press `OK`
+  1. Newly added torrents will have appropriate stop seed time set
+  ![Image of Yaktocat](https://cloud.githubusercontent.com/assets/8310169/14019955/7783c858-f1ab-11e5-9fe1-9cc9e0b307c1.png)

--- a/deluge_seedtime/__init__.py
+++ b/deluge_seedtime/__init__.py
@@ -39,20 +39,34 @@
 
 from deluge.plugins.init import PluginInitBase
 
+
 class CorePlugin(PluginInitBase):
     def __init__(self, plugin_name):
-        from core import Core as _plugin_cls
-        self._plugin_cls = _plugin_cls
+        from .core import Core as PluginClass
+
+        self._plugin_cls = PluginClass
         super(CorePlugin, self).__init__(plugin_name)
+
 
 class GtkUIPlugin(PluginInitBase):
     def __init__(self, plugin_name):
-        from gtkui import GtkUI as _plugin_cls
-        self._plugin_cls = _plugin_cls
+        from .gtkui import GtkUI as PluginClass
+
+        self._plugin_cls = PluginClass
         super(GtkUIPlugin, self).__init__(plugin_name)
+
+
+class Gtk3UIPlugin(PluginInitBase):
+    def __init__(self, plugin_name):
+        from .gtk3ui import Gtk3UI as PluginClass
+
+        self._plugin_cls = PluginClass
+        super(Gtk3UIPlugin, self).__init__(plugin_name)
+
 
 class WebUIPlugin(PluginInitBase):
     def __init__(self, plugin_name):
-        from webui import WebUI as _plugin_cls
-        self._plugin_cls = _plugin_cls
+        from .webui import WebUI as PluginClass
+
+        self._plugin_cls = PluginClass
         super(WebUIPlugin, self).__init__(plugin_name)

--- a/deluge_seedtime/common.py
+++ b/deluge_seedtime/common.py
@@ -1,5 +1,5 @@
 #
-# webui.py
+# common.py
 #
 # Copyright (C) 2009 Chase Sterling <chase.sterling@gmail.com>
 #
@@ -36,16 +36,12 @@
 #    this exception statement from your version. If you delete this exception
 #    statement from all source files in the program, then also delete it here.
 #
+from __future__ import unicode_literals
 
-import logging
+import os.path
 
-from deluge.plugins.pluginbase import WebPluginBase
+from pkg_resources import resource_filename
 
-from common import get_resource
 
-log = logging.getLogger(__name__)
-
-class WebUI(WebPluginBase):
-
-    scripts = [get_resource("seedtime.js")]
-    debug_scripts = scripts
+def get_resource(filename):
+    return resource_filename(__package__, os.path.join("data", filename))

--- a/deluge_seedtime/core.py
+++ b/deluge_seedtime/core.py
@@ -36,46 +36,57 @@
 #    this exception statement from your version. If you delete this exception
 #    statement from all source files in the program, then also delete it here.
 #
+from __future__ import unicode_literals
 
+import logging
 import re
-from twisted.internet.task import LoopingCall, deferLater
-from twisted.internet import reactor
-from deluge.log import LOG as log
-from deluge.plugins.pluginbase import CorePluginBase
+
 import deluge.component as component
 import deluge.configmanager
 from deluge.core.rpcserver import export
+from deluge.plugins.pluginbase import CorePluginBase
+from twisted.internet import reactor
+from twisted.internet.task import LoopingCall, deferLater
+
+log = logging.getLogger(__name__)
 
 CONFIG_DEFAULT = {
     "default_stop_time": 7,
     "remove_torrent": False,
     "delay_time": 1,  # delay between adding torrent and setting initial seed time (in seconds)
-    "filter_list": [], #example: {'field': 'tracker', 'filter': ".*", 'stop_time': 7.0}],
-    "torrent_stop_times": {}  # torrent_id: stop_time (in hours)
+    "filter_list": [],  # example: {'field': 'tracker', 'filter': ".*", 'stop_time': 7.0}],
+    "torrent_stop_times": {},  # torrent_id: stop_time (in hours)
 }
 
+
 class Core(CorePluginBase):
-
-    #update_interval = 30
-
     def enable(self):
-        self.config = deluge.configmanager.ConfigManager("seedtime.conf", CONFIG_DEFAULT)
+        self.config = deluge.configmanager.ConfigManager(
+            "seedtime.conf", CONFIG_DEFAULT
+        )
         self.torrent_stop_times = self.config["torrent_stop_times"]
         self.delay_time = self.config["delay_time"]
-        self.torrent_manager = component.get("TorrentManager")
         self.plugin = component.get("CorePluginManager")
-        self.plugin.register_status_field("seed_stop_time", self._status_get_seed_stop_time)
-        self.plugin.register_status_field("seed_time_remaining", self._status_get_remaining_seed_time)
+        self.plugin.register_status_field(
+            "seed_stop_time", self._status_get_seed_stop_time
+        )
+        self.plugin.register_status_field(
+            "seed_time_remaining", self._status_get_remaining_seed_time
+        )
         self.torrent_manager = component.get("TorrentManager")
 
-        component.get("EventManager").register_event_handler("TorrentAddedEvent", self.post_torrent_add)
-        component.get("EventManager").register_event_handler("TorrentRemovedEvent", self.post_torrent_remove)
+        component.get("EventManager").register_event_handler(
+            "TorrentAddedEvent", self.post_torrent_add
+        )
+        component.get("EventManager").register_event_handler(
+            "TorrentRemovedEvent", self.post_torrent_remove
+        )
 
         self.looping_call = LoopingCall(self.update_checker)
         deferLater(reactor, 5, self.start_looping)
 
     def start_looping(self):
-        log.warning('seedtime loop starting')
+        log.warning("seedtime loop starting")
         self.looping_call.start(10)
 
     def disable(self):
@@ -89,19 +100,27 @@ class Core(CorePluginBase):
 
     def update_checker(self):
         """Check if any torrents have reached their stop seed time."""
-        for torrent in component.get("Core").torrentmanager.torrents.values():
-            if not (torrent.state == "Seeding" and torrent.torrent_id in self.torrent_stop_times):
+        for torrent_id in self.torrent_manager.torrents:
+            torrent = self.torrent_manager.torrents[torrent_id]
+            if not (
+                torrent.state == "Seeding" and torrent_id in self.torrent_stop_times
+            ):
                 continue
-            stop_time = self.torrent_stop_times[torrent.torrent_id]
-            if torrent.get_status(['seeding_time'])['seeding_time'] > stop_time * 3600.0 * 24.0:
-                if self.config['remove_torrent']:
-                    self.torrent_manager.remove(torrent.torrent_id)
+            stop_time = self.torrent_stop_times[torrent_id]
+            if (
+                torrent.get_status(["seeding_time"])["seeding_time"]
+                > stop_time * 3600.0 * 24.0
+            ):
+                if self.config["remove_torrent"]:
+                    self.torrent_manager.remove(torrent_id)
                 else:
                     torrent.pause()
 
     ## Plugin hooks ##
     def post_torrent_add(self, torrent_id, from_state=None):
-        if from_state == True or (from_state == None and not self.torrent_manager.session_started):
+        if from_state or (
+            from_state is None and not self.torrent_manager.session_started
+        ):
             return
         log.debug("seedtime post_torrent_add")
 
@@ -111,42 +130,46 @@ class Core(CorePluginBase):
         deferLater(reactor, self.delay_time, self.apply_filter, torrent_id)
 
     def apply_filter(self, torrent_id):
-        for filter_list in self.config['filter_list']:
+        for filter_list in self.config["filter_list"]:
             search_strs = None
             stop_time = None
-            if filter_list['field'] == 'label':
-                if 'Label' in component.get("CorePluginManager").get_enabled_plugins():
+            if filter_list["field"] == "label":
+                if "Label" in component.get("CorePluginManager").get_enabled_plugins():
                     try:  # If label plugin changes and code no longer works, ignore this filter
                         # Can't seem to retrieve label from torrent manager so we must use the label plugin methods
                         # label_str = component.get("TorrentManager")[torrent_id].get_status(["label"])
-                        label_str = component.get("CorePlugin.Label")._status_get_label(torrent_id)
+                        label_str = component.get("CorePlugin.Label")._status_get_label(
+                            torrent_id
+                        )
                         if len(label_str) > 0:
                             search_strs = [label_str]
                     except:
-                        log.debug('Cannot find torrent label')
-            elif filter_list['field'] == 'tracker':
+                        log.debug("Cannot find torrent label")
+            elif filter_list["field"] == "tracker":
                 torrent = component.get("TorrentManager")[torrent_id]
                 trackers = torrent.get_status(["trackers"])["trackers"]
                 search_strs = [tracker["url"] for tracker in trackers]
-            elif filter_list['field'] == 'default':
-                search_strs = ['']
+            elif filter_list["field"] == "default":
+                search_strs = [""]
             else:  # unknown filter, ignore
                 pass
 
             if search_strs is not None:
                 for search_str in search_strs:
-                    if re.search(filter_list['filter'], search_str) is not None:
-                        stop_time = filter_list['stop_time']
-                        log.debug('filter %s matched %s %s' %
-                                  (filter_list['filter'], filter_list['field'], search_str))
+                    if re.search(filter_list["filter"], search_str) is not None:
+                        stop_time = filter_list["stop_time"]
+                        log.debug(
+                            "filter %s matched %s %s"
+                            % (filter_list["filter"], filter_list["field"], search_str)
+                        )
                 if stop_time is not None:
-                    log.debug('applying stop.... time %r' % stop_time)
+                    log.debug("applying stop.... time %r" % stop_time)
                     self.set_torrent(torrent_id, stop_time)
                     break  # stop looking through filter list
-        else: #apply default if no filters match
-            stop_time = self.config['default_stop_time']
+        else:  # apply default if no filters match
+            stop_time = self.config["default_stop_time"]
             if stop_time > 0:
-                log.debug('applying stop.... time %r' % stop_time)
+                log.debug("applying stop.... time %r" % stop_time)
                 self.set_torrent(torrent_id, stop_time)
 
     def post_torrent_remove(self, torrent_id):
@@ -157,9 +180,12 @@ class Core(CorePluginBase):
     @export
     def set_config(self, config):
         """Sets the config dictionary"""
-        log.debug('seedtime %r' % config)
-        log.debug('component state %r, component timer %r' % (self._component_state, self._component_timer))
-        for key in config.keys():
+        log.debug("seedtime %r" % config)
+        log.debug(
+            "component state %r, component timer %r"
+            % (self._component_state, self._component_timer)
+        )
+        for key in config:
             self.config[key] = config[key]
         self.config.save()
 
@@ -169,7 +195,7 @@ class Core(CorePluginBase):
         return self.config.config
 
     @export
-    def set_torrent(self, torrent_id , stop_time):
+    def set_torrent(self, torrent_id, stop_time):
         if stop_time is None or stop_time < 0:
             del self.torrent_stop_times[torrent_id]
         else:
@@ -184,5 +210,5 @@ class Core(CorePluginBase):
         """Returns the stop seed time for the torrent."""
         stop_time = self._status_get_seed_stop_time(torrent_id)
         torrent = component.get("TorrentManager")[torrent_id]
-        seed_time = torrent.get_status(['seeding_time'])['seeding_time']
-        return max(0, stop_time-seed_time)
+        seed_time = torrent.get_status(["seeding_time"])["seeding_time"]
+        return max(0, stop_time - seed_time)

--- a/deluge_seedtime/data/config.ui
+++ b/deluge_seedtime/data/config.ui
@@ -1,138 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glade-interface>
-  <!-- interface-requires gtk+ 2.16 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-  <widget class="GtkDialog" id="dlg_custom_time">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="modal">True</property>
-    <property name="type_hint">normal</property>
-    <child internal-child="vbox">
-      <widget class="GtkVBox" id="dialog-vbox1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <widget class="GtkHButtonBox" id="dialog-action_area1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <widget class="GtkButton" id="button2">
-                <property name="label">gtk-cancel</property>
-                <property name="response_id">-6</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-                <property name="yalign">0.49000000953674316</property>
-              </widget>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkButton" id="button1">
-                <property name="label">gtk-ok</property>
-                <property name="response_id">-5</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </widget>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </widget>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <widget class="GtkHBox" id="hbox1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <widget class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Stop seeding after</property>
-                <property name="justify">right</property>
-              </widget>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="padding">3</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkEntry" id="txt_custom_stop_time">
-                <property name="width_request">45</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="invisible_char">●</property>
-                <property name="activates_default">True</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-              </widget>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkLabel" id="label2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">days.</property>
-              </widget>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="padding">3</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </widget>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </widget>
-    </child>
-  </widget>
-  <widget class="GtkWindow" id="window1">
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.10"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">999</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="lower">1</property>
+    <property name="upper">99999</property>
+    <property name="value">1</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
     <child>
-      <widget class="GtkVBox" id="prefs_box">
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkVBox" id="prefs_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <widget class="GtkCheckButton" id="chk_remove_torrent">
+          <object class="GtkCheckButton" id="chk_remove_torrent">
             <property name="label" translatable="yes">Remove torrent when stopping</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="use_action_appearance">False</property>
             <property name="xalign">0.50999999046325684</property>
             <property name="draw_indicator">True</property>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
@@ -141,24 +40,22 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkHBox" id="hbox2">
+          <object class="GtkHBox" id="hbox2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <widget class="GtkSpinButton" id="default_stop_time">
+              <object class="GtkSpinButton" id="default_stop_time">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip" translatable="yes">Default stop seed time if no filter matches. Default time of 0 means infinite seed time.</property>
+                <property name="tooltip_text" translatable="yes">Default stop seed time if no filter matches. Default time of 0 means infinite seed time.</property>
                 <property name="invisible_char">•</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-                <property name="adjustment">0 0 999 0.01 10 0</property>
+                <property name="adjustment">adjustment1</property>
                 <property name="digits">2</property>
                 <property name="snap_to_ticks">True</property>
                 <property name="numeric">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -166,19 +63,19 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkLabel" id="default_time_label">
+              <object class="GtkLabel" id="default_time_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0.05000000074505806</property>
                 <property name="label" translatable="yes">Default stop time (days)</property>
-              </widget>
+                <property name="xalign">0.05000000074505806</property>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
@@ -186,23 +83,21 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkHBox" id="hbox1">
+          <object class="GtkHBox" id="hbox3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <widget class="GtkSpinButton" id="delay_time">
+              <object class="GtkSpinButton" id="delay_time">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip" translatable="yes">Wait this long after torrent is added before setting initial stop seed time. Gives the user time to setup things such as labels.</property>
+                <property name="tooltip_text" translatable="yes">Wait this long after torrent is added before setting initial stop seed time. Gives the user time to setup things such as labels.</property>
                 <property name="invisible_char">•</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-                <property name="adjustment">1 1 99999 1 10 0</property>
+                <property name="adjustment">adjustment2</property>
                 <property name="snap_to_ticks">True</property>
                 <property name="numeric">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -210,19 +105,19 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkLabel" id="delay_time_label">
+              <object class="GtkLabel" id="delay_time_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0.05000000074505806</property>
                 <property name="label" translatable="yes">delay (seconds)</property>
-              </widget>
+                <property name="xalign">0.05000000074505806</property>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
@@ -230,34 +125,31 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkTable" id="table1">
+          <object class="GtkTable" id="table1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="n_rows">5</property>
             <property name="n_columns">2</property>
             <child>
-              <widget class="GtkScrolledWindow" id="scrolledwindow1">
+              <object class="GtkScrolledWindow" id="scrolledwindow1">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
                 <child>
                   <placeholder/>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="bottom_attach">5</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnUp">
+              <object class="GtkButton" id="btnUp">
                 <property name="label">gtk-go-up</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -268,14 +160,13 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnDown">
+              <object class="GtkButton" id="btnDown">
                 <property name="label">gtk-go-down</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -286,14 +177,13 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnAdd">
+              <object class="GtkButton" id="btnAdd">
                 <property name="label">gtk-add</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -302,14 +192,13 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnRemove">
+              <object class="GtkButton" id="btnRemove">
                 <property name="label">gtk-remove</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -320,10 +209,10 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkLabel" id="label1">
+              <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -332,14 +221,14 @@
                 <property name="x_options">GTK_SHRINK | GTK_FILL</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">3</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+</interface>

--- a/deluge_seedtime/data/dialog.ui
+++ b/deluge_seedtime/data/dialog.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.10"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">999</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="lower">1</property>
+    <property name="upper">99999</property>
+    <property name="value">1</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkDialog" id="dlg_custom_time">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="modal">True</property>
+    <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button2">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <property name="yalign">0.49000000953674316</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkHBox" id="hbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Stop seeding after</property>
+                <property name="justify">right</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">3</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="txt_custom_stop_time">
+                <property name="width_request">45</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="invisible_char">●</property>
+                <property name="activates_default">True</property>
+                <property name="primary_icon_activatable">False</property>
+                <property name="secondary_icon_activatable">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">days.</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">3</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">button2</action-widget>
+      <action-widget response="-5">button1</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/deluge_seedtime/data/seedtime.js
+++ b/deluge_seedtime/data/seedtime.js
@@ -48,9 +48,9 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         type: 'vbox',
         align: 'stretch'
     },
-    hasReadConfig : false,
+    hasReadConfig: false,
 
-    initComponent: function() {
+    initComponent: function () {
         Deluge.ux.preferences.SeedTimePage.superclass.initComponent.call(this);
 
         this.form = this.add({
@@ -60,47 +60,47 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         });
 
         this.settings = this.form.add({
-          xtype : 'fieldset',
-          border : false,
-          title : _('Settings'),
-          defaultType : 'spinnerfield',
-          defaults : {minValue : -1, maxValue : 99999},
-          style : 'margin-top: 5px; margin-bottom: 0px; padding-bottom: 0px;',
-          labelWidth : 200,
-          items : [
-            {
-              xtype : "checkbox",
-              fieldLabel : 'Remove torrent when stopping',
-              name : 'chk_remove_torrent',
-              checked : true,
-              id : 'rm_torrent_checkbox'
-            },
-            {
-              fieldLabel : _('Default stop time (days)'),
-              name : 'default_stop_time',
-              width : 80,
-              value : 30,
-              minValue : 0,
-              maxValue : 999,
-              decimalPrecision : 2,
-              id : 'default_stop_time'
-            },
-            {
-              fieldLabel : _('Delay (seconds)'),
-              name : 'delay_time',
-              width : 80,
-              value : 30,
-              minValue : 1,
-              maxValue : 300,
-              decimalPrecision : 0,
-              id : 'torrent_delay'
-            }
-          ]
+            xtype: 'fieldset',
+            border: false,
+            title: _('Settings'),
+            defaultType: 'spinnerfield',
+            defaults: { minValue: -1, maxValue: 99999 },
+            style: 'margin-top: 5px; margin-bottom: 0px; padding-bottom: 0px;',
+            labelWidth: 200,
+            items: [
+                {
+                    xtype: "checkbox",
+                    fieldLabel: 'Remove torrent when stopping',
+                    name: 'chk_remove_torrent',
+                    checked: true,
+                    id: 'rm_torrent_checkbox'
+                },
+                {
+                    fieldLabel: _('Default stop time (days)'),
+                    name: 'default_stop_time',
+                    width: 80,
+                    value: 30,
+                    minValue: 0,
+                    maxValue: 999,
+                    decimalPrecision: 2,
+                    id: 'default_stop_time'
+                },
+                {
+                    fieldLabel: _('Delay (seconds)'),
+                    name: 'delay_time',
+                    width: 80,
+                    value: 30,
+                    minValue: 1,
+                    maxValue: 300,
+                    decimalPrecision: 0,
+                    id: 'torrent_delay'
+                }
+            ]
         });
 
         // create reusable renderer
-        Ext.util.Format.comboRenderer = function(combo){
-            return function(value){
+        Ext.util.Format.comboRenderer = function (combo) {
+            return function (value) {
                 var record = combo.findRecord(combo.valueField, value);
                 return record ? record.get(combo.displayField) : combo.valueNotFoundText;
             }
@@ -108,9 +108,9 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
 
         // create the combo instance
         var combo = new Ext.form.ComboBox({
-            editable:false,
+            editable: false,
             triggerAction: 'all',
-            lazyRender:true,
+            lazyRender: true,
             mode: 'local',
             store: new Ext.data.ArrayStore({
                 id: 0,
@@ -122,49 +122,53 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         });
 
         this.filter_list = new Ext.grid.EditorGridPanel({
-          height: 300,  //TODO: instead of hard coding, expand height automatically
-          flex: 1,
-          store : new Ext.data.JsonStore({
-            fields : [
-              {name : 'field', type : 'string'},
-              {name : 'filter', type : 'string'},
-              {name : 'stop_time', type : 'float'},
-            ],
-            id : 0
-          }),
-          colModel : new Ext.grid.ColumnModel({
-            defaults : {sortable : false, menuDisabled : true},
-            columns : [
-              {
-                header : 'Field',
-                width : .24,
-                sortable : false,
-                dataIndex : 'field',
-                editor : combo,
-                renderer : Ext.util.Format.comboRenderer(combo),
-              },
-              { header : 'Filter',
-                width : .50,
-                dataIndex : 'filter',
-                editor : {xtype : 'textfield' },
-              },
-              { header : 'Stop Seed Time (days)',
-                width : .26,
-                editor : { xtype : 'numberfield',
-                           maxValue : 365.0,
-                           minValue : 0.01 },
-                dataIndex : 'stop_time'
-              },
-            ]
-          }),
-          viewConfig : {forceFit : true},
-          selModel : new Ext.grid.RowSelectionModel({singleSelect : true, moveEditorOnEnter : false}),
+            height: 300,  //TODO: instead of hard coding, expand height automatically
+            flex: 1,
+            store: new Ext.data.JsonStore({
+                fields: [
+                    { name: 'field', type: 'string' },
+                    { name: 'filter', type: 'string' },
+                    { name: 'stop_time', type: 'float' },
+                ],
+                id: 0
+            }),
+            colModel: new Ext.grid.ColumnModel({
+                defaults: { sortable: false, menuDisabled: true },
+                columns: [
+                    {
+                        header: 'Field',
+                        width: .24,
+                        sortable: false,
+                        dataIndex: 'field',
+                        editor: combo,
+                        renderer: Ext.util.Format.comboRenderer(combo),
+                    },
+                    {
+                        header: 'Filter',
+                        width: .50,
+                        dataIndex: 'filter',
+                        editor: { xtype: 'textfield' },
+                    },
+                    {
+                        header: 'Stop Seed Time (days)',
+                        width: .26,
+                        editor: {
+                            xtype: 'numberfield',
+                            maxValue: 365.0,
+                            minValue: 0.01
+                        },
+                        dataIndex: 'stop_time'
+                    },
+                ]
+            }),
+            viewConfig: { forceFit: true },
+            selModel: new Ext.grid.RowSelectionModel({ singleSelect: true, moveEditorOnEnter: false }),
         });
 
-        this.filter_list.addButton({text:"Up", iconCls: 'icon-up'}, this.filterUp, this);
-        this.filter_list.addButton({text:"Down", iconCls: 'icon-down'}, this.filterDown, this);
-        this.filter_list.addButton({text:"Add", iconCls: 'icon-add'}, this.filterAdd, this);
-        this.filter_list.addButton({text:"Remove", iconCls: 'icon-remove'}, this.filterRemove, this);
+        this.filter_list.addButton({ text: "Up", iconCls: 'icon-up' }, this.filterUp, this);
+        this.filter_list.addButton({ text: "Down", iconCls: 'icon-down' }, this.filterDown, this);
+        this.filter_list.addButton({ text: "Add", iconCls: 'icon-add' }, this.filterAdd, this);
+        this.filter_list.addButton({ text: "Remove", iconCls: 'icon-remove' }, this.filterRemove, this);
         this.form.add(this.filter_list);
 
         this.defaultStoptime = this.settings.items.get("default_stop_time");
@@ -173,53 +177,53 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         this.on('show', this.updateConfig, this);
     },
 
-    filterUp: function() {
+    filterUp: function () {
         var store = this.filter_list.getStore();
         var sm = this.filter_list.getSelectionModel();
         var selected_rec = sm.getSelected();
         var selected_indx = store.indexOf(selected_rec);
 
-        if (selected_indx > 0 ) {
-          store.remove(selected_rec);
-          store.insert(selected_indx-1, selected_rec);
-          sm.selectRow(selected_indx-1);
+        if (selected_indx > 0) {
+            store.remove(selected_rec);
+            store.insert(selected_indx - 1, selected_rec);
+            sm.selectRow(selected_indx - 1);
         }
     },
 
-    filterDown: function() {
+    filterDown: function () {
         var store = this.filter_list.getStore();
         var sm = this.filter_list.getSelectionModel();
         var selected_rec = sm.getSelected();
         var selected_indx = store.indexOf(selected_rec);
 
-        if (selected_indx < store.getCount()-1 ) {
-          store.remove(selected_rec);
-          store.insert(selected_indx+1, selected_rec);
-          sm.selectRow(selected_indx+1);
+        if (selected_indx < store.getCount() - 1) {
+            store.remove(selected_rec);
+            store.insert(selected_indx + 1, selected_rec);
+            sm.selectRow(selected_indx + 1);
         }
     },
 
-    filterAdd: function() {
+    filterAdd: function () {
         var store = this.filter_list.getStore();
-        store.insert(0, new store.recordType({ field : "label", filter : "RegEx", stop_time : 3.0}));
+        store.insert(0, new store.recordType({ field: "label", filter: "RegEx", stop_time: 3.0 }));
     },
 
-    filterRemove: function() {
+    filterRemove: function () {
         var store = this.filter_list.getStore();
         var selected_rec = this.filter_list.getSelectionModel().getSelected();
         store.remove(selected_rec);
     },
 
-    onRender: function(ct, position) {
+    onRender: function (ct, position) {
         Deluge.ux.preferences.SeedTimePage.superclass.onRender.call(this, ct, position);
     },
 
-    onApply: function() {
-        if(this.hasReadConfig) {
+    onApply: function () {
+        if (this.hasReadConfig) {
             //TODO: got to be a better way to get json out of the store, JsonWriter?
             var filter_items = []
             var items = this.filter_list.getStore().data.items;
-            for(i=0; i < items.length; i++) {
+            for (i = 0; i < items.length; i++) {
                 filter_items.push(items[i].data);
             }
 
@@ -233,13 +237,13 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         }
     },
 
-    onOk: function() {
+    onOk: function () {
         this.onApply();
     },
 
-    updateConfig: function() {
+    updateConfig: function () {
         deluge.client.seedtime.get_config({
-            success: function(config) {
+            success: function (config) {
                 this.removeWhenStopped.setValue(config['remove_torrent']);
                 this.filter_list.getStore().loadData(config['filter_list']);
                 this.delayTime.setValue(config['delay_time']);
@@ -257,7 +261,7 @@ Deluge.ux.CustomSeedtimeWindow = Ext.extend(Ext.Window, {
     width: 300,
     height: 100,
 
-    initComponent: function() {
+    initComponent: function () {
         Deluge.ux.CustomSeedtimeWindow.superclass.initComponent.call(this);
         this.addButton(_('Cancel'), this.onCancelClick, this);
         this.addButton(_('Ok'), this.onOkClick, this);
@@ -266,44 +270,44 @@ Deluge.ux.CustomSeedtimeWindow = Ext.extend(Ext.Window, {
             xtype: 'form',
             height: 35,
             baseCls: 'x-plain',
-            bodyStyle:'padding:5px 5px 0',
+            bodyStyle: 'padding:5px 5px 0',
             defaultType: 'numberfield',
             labelWidth: 220,
             items: [{
-                    fieldLabel: _('Stop Time (Days)'),
-                    name: 'stop_time',
-                    allowBlank: false,
-                    maxValue : 365.0,
-                    minValue : 0.01,
-                    width: 50,
-                    listeners: {
-                        'specialkey': {
-                            fn: function(field, e) {
-                                if (e.getKey() == 13) this.onOkClick();
-                            },
-                            scope: this
-                        }
+                fieldLabel: _('Stop Time (Days)'),
+                name: 'stop_time',
+                allowBlank: false,
+                maxValue: 365.0,
+                minValue: 0.01,
+                width: 50,
+                listeners: {
+                    'specialkey': {
+                        fn: function (field, e) {
+                            if (e.getKey() == 13) this.onOkClick();
+                        },
+                        scope: this
                     }
-                }]
+                }
+            }]
         });
     },
 
-    onCancelClick: function() {
+    onCancelClick: function () {
         this.hide();
     },
 
-    onOkClick: function() {
+    onOkClick: function () {
         this.item.stop_time = this.form.getForm().findField('stop_time').getValue();
         this.setStoptime(this.item, this.e)
         this.hide();
     },
 
-    onHide: function(comp) {
+    onHide: function (comp) {
         Deluge.ux.CustomSeedtimeWindow.superclass.onHide.call(this, comp);
         this.form.getForm().reset();
     },
 
-    onShow: function(comp) {
+    onShow: function (comp) {
         Deluge.ux.CustomSeedtimeWindow.superclass.onShow.call(this, comp);
         this.form.getForm().findField('stop_time').focus(false, 150);
     }
@@ -313,34 +317,37 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
 
     name: 'SeedTime',
 
-    createMenu: function() {
+    createMenu: function () {
         menuTimes = [1, 2, 3, 7, 14, 30],
-        itemslist = [{  text: _('Never'),
-                        stop_time : -1,
-                        handler: this.setStoptime,
-                        scope: this
-                }];
-        for(indx=0; indx < menuTimes.length; indx++) {
-            itemslist.push({  text: _(menuTimes[indx] + ' Days'),
-                        stop_time : menuTimes[indx],
-                        handler: this.setStoptime,
-                        scope: this
-                    });
+            itemslist = [{
+                text: _('Never'),
+                stop_time: -1,
+                handler: this.setStoptime,
+                scope: this
+            }];
+        for (indx = 0; indx < menuTimes.length; indx++) {
+            itemslist.push({
+                text: _(menuTimes[indx] + ' Days'),
+                stop_time: menuTimes[indx],
+                handler: this.setStoptime,
+                scope: this
+            });
         }
-        itemslist.push({text: _('Custom'),
-                        stop_time : 1,
-                        handler: this.setCustomStoptime,
-                        scope: this
-                        });
-        this.torrentMenu = new Ext.menu.Menu({items: itemslist});
+        itemslist.push({
+            text: _('Custom'),
+            stop_time: 1,
+            handler: this.setCustomStoptime,
+            scope: this
+        });
+        this.torrentMenu = new Ext.menu.Menu({ items: itemslist });
     },
 
-    setStoptime: function(item, e) {
+    setStoptime: function (item, e) {
         var ids = deluge.torrents.getSelectedIds();
-        Ext.each(ids, function(id, i) {
+        Ext.each(ids, function (id, i) {
             if (ids.length == i + 1) {
                 deluge.client.seedtime.set_torrent(id, item.stop_time, {
-                    success: function() {
+                    success: function () {
                         deluge.ui.update();
                     }
                 });
@@ -350,7 +357,7 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
         });
     },
 
-    setCustomStoptime: function(item, e) {
+    setCustomStoptime: function (item, e) {
         if (!this.customTimeWindow) {
             this.customTimeWindow = new Deluge.ux.CustomSeedtimeWindow();
             this.customTimeWindow.setStoptime = this.setStoptime;
@@ -360,7 +367,7 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
         this.customTimeWindow.show();
     },
 
-    onDisable: function() {
+    onDisable: function () {
         deluge.preferences.removePage(this.prefsPage);
         deluge.menus.torrent.remove(this.tmSep);
         deluge.menus.torrent.remove(this.tm);
@@ -369,7 +376,7 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
         this.deregisterTorrentStatus('seed_time_remaining');
     },
 
-    onEnable: function() {
+    onEnable: function () {
         //preference page
         this.prefsPage = deluge.preferences.addPage(new Deluge.ux.preferences.SeedTimePage());
 
@@ -383,18 +390,18 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
             menu: this.torrentMenu
         });
 
-        ftimewithnull = function(n) {
-                if(n==null) {return "";}
-                else if(n == 0) {n=0.1} // avoid 0 being infinite
-                return Deluge.Formatters.timeRemaining(n);
-            };
+        ftimewithnull = function (n) {
+            if (n == null) { return ""; }
+            else if (n == 0) { n = 0.1 } // avoid 0 being infinite
+            return Deluge.Formatters.timeRemaining(n);
+        };
         // status columns
         this.registerTorrentStatus('seeding_time', _('Seed Time'),
-            { colCfg : { sortable : true, renderer : ftimewithnull}});
+            { colCfg: { sortable: true, renderer: ftimewithnull } });
         this.registerTorrentStatus('seed_stop_time', _('Stop Seed Time'),
-            { colCfg : { sortable : true, renderer : ftimewithnull}});
+            { colCfg: { sortable: true, renderer: ftimewithnull } });
         this.registerTorrentStatus('seed_time_remaining', _('Remaining Seed Time'),
-            { colCfg : { sortable : true, renderer : ftimewithnull}});
+            { colCfg: { sortable: true, renderer: ftimewithnull } });
     }
 });
 Deluge.registerPlugin('SeedTime', SeedTimePlugin);

--- a/deluge_seedtime/gtk3ui.py
+++ b/deluge_seedtime/gtk3ui.py
@@ -1,0 +1,288 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 Jeff VanOss <vanossj@gmail.com>
+#
+# Basic plugin template created by the Deluge Team.
+#
+# This file is part of test_plugin and is licensed under GNU GPL 3.0, or later,
+# with the additional special exception to link portions of this program with
+# the OpenSSL library. See LICENSE for more details.
+
+
+import logging
+
+from gi.repository import Gtk
+
+import deluge.component as component
+from deluge.plugins.pluginbase import Gtk3PluginBase
+from deluge.ui.client import client
+
+try:
+    from deluge.ui.gtk3.listview import cell_data_time
+except ImportError:
+    from deluge.ui.gtk3.torrentview_data_funcs import cell_data_time
+
+from .common import get_resource
+
+log = logging.getLogger(__name__)
+
+
+class Gtk3UI(Gtk3PluginBase):
+    def enable(self):
+        self.builder = Gtk.Builder()
+        self.builder.add_from_file(get_resource("config.ui"))
+
+        component.get("Preferences").add_page(
+            "SeedTime", self.builder.get_object("prefs_box")
+        )
+        component.get("PluginManager").register_hook(
+            "on_apply_prefs", self.on_apply_prefs
+        )
+        component.get("PluginManager").register_hook(
+            "on_show_prefs", self.on_show_prefs
+        )
+        # Columns
+        torrentview = component.get("TorrentView")
+        torrentview.add_func_column(
+            _("Seed Time"), cell_data_time, [int], status_field=["seeding_time"]
+        )
+        torrentview.add_func_column(
+            _("Stop Seed Time"), cell_data_time, [int], status_field=["seed_stop_time"]
+        )
+        torrentview.add_func_column(
+            _("Remaining Seed Time"),
+            cell_data_time,
+            [int],
+            status_field=["seed_time_remaining"],
+        )
+        # Submenu
+        log.debug("add items to torrentview-popup menu.")
+        torrentmenu = component.get("MenuBar").torrentmenu
+        self.seedtime_menu = SeedTimeMenu()
+        torrentmenu.append(self.seedtime_menu)
+        self.seedtime_menu.show_all()
+
+        # Build Preference filter table
+        self.setupFilterTable()
+
+    def setupFilterTable(self):
+        # Setup filter button callbacks
+        self.btnAdd = self.builder.get_object("btnAdd")
+        self.btnAdd.connect("clicked", self.btnAddCallback)
+        self.btnRemove = self.builder.get_object("btnRemove")
+        self.btnRemove.connect("clicked", self.btnRemoveCallback)
+        self.btnUp = self.builder.get_object("btnUp")
+        self.btnUp.connect("clicked", self.btnUpCallback)
+        self.btnDown = self.builder.get_object("btnDown")
+        self.btnDown.connect("clicked", self.btnDownCallback)
+
+        # cell by cell renderer callback, changes field and filter to editable
+        def rowRendererCb(column, cell, model, row, data):
+            cell.set_property("editable", True)
+
+        # creating the treeview,and add columns
+        self.treeview = Gtk.TreeView()
+
+        # setup Field column
+        liststore_field = Gtk.ListStore(str)
+        for item in ["tracker", "label"]:
+            liststore_field.append([item])
+        renderer = Gtk.CellRendererCombo()
+        renderer.set_property("editable", True)
+        renderer.set_property("model", liststore_field)
+        renderer.set_property("text-column", 0)
+        renderer.set_property("has-entry", False)
+        renderer.connect("edited", self.on_field_changed)
+        column = Gtk.TreeViewColumn("Field", renderer, text=0)
+        column.set_cell_data_func(renderer, rowRendererCb)
+        label = Gtk.Label("Field")
+        column.set_widget(label)
+        label.set_tooltip_text("Torrent Field to filter.")
+        label.show()
+        self.treeview.append_column(column)
+
+        # setup Filter column
+        renderer = Gtk.CellRendererText()
+        renderer.set_property("editable", True)
+        renderer.connect("edited", self.on_filter_changed)
+        column = Gtk.TreeViewColumn("Filter", renderer, text=1)
+        column.set_cell_data_func(renderer, rowRendererCb)
+        label = Gtk.Label("Filter")
+        column.set_widget(label)
+        label.set_tooltip_text("RegEx filter to apply to Field")
+        label.show()
+
+        self.treeview.append_column(column)
+
+        # setup stop time column
+        renderer = Gtk.CellRendererSpin()
+        renderer.connect("edited", self.on_stoptime_edited)
+        renderer.set_property("editable", True)
+        adjustment = Gtk.Adjustment(0, 0, 100, 1, 10, 0)
+        renderer.set_property("adjustment", adjustment)
+        column = Gtk.TreeViewColumn("Stop Seed Time (days)", renderer, text=2)
+        label = Gtk.Label("Stop Seed Time (days)")
+        column.set_widget(label)
+        label.set_tooltip_text(
+            "Set the amount of time a torrent seeds for "
+            "before being stopped. Default value is editable"
+        )
+        label.show()
+        self.treeview.append_column(column)
+
+        self.sw1 = self.builder.get_object("scrolledwindow1")
+        self.sw1.add(self.treeview)
+        self.sw1.show_all()
+
+    def disable(self):
+        component.get("Preferences").remove_page("SeedTime")
+        component.get("PluginManager").deregister_hook(
+            "on_apply_prefs", self.on_apply_prefs
+        )
+        component.get("PluginManager").deregister_hook(
+            "on_show_prefs", self.on_show_prefs
+        )
+        try:
+            # Columns
+            component.get("TorrentView").remove_column(_("Seed Time"))
+            component.get("TorrentView").remove_column(_("Stop Seed Time"))
+            component.get("TorrentView").remove_column(_("Remaining Seed Time"))
+            # Submenu
+            torrentmenu = component.get("MenuBar").torrentmenu
+            torrentmenu.remove(self.seedtime_menu)
+        except Exception as e:
+            log.debug(e)
+
+    def on_apply_prefs(self):
+        log.debug("applying prefs for SeedTime")
+
+        config = {
+            "remove_torrent": self.builder.get_object(
+                "chk_remove_torrent"
+            ).get_active(),
+            "filter_list": list(
+                {"field": row[0], "filter": row[1], "stop_time": row[2]}
+                for row in self.liststore
+            ),
+            "delay_time": self.builder.get_object("delay_time").get_value_as_int(),
+            "default_stop_time": self.builder.get_object(
+                "default_stop_time"
+            ).get_value(),
+        }
+        client.seedtime.set_config(config)
+
+    def on_show_prefs(self):
+        client.seedtime.get_config().addCallback(self.cb_get_config)
+
+    def cb_get_config(self, config):
+        """callback for on show_prefs"""
+        log.debug("cb get config seedtime")
+        self.builder.get_object("chk_remove_torrent").set_active(
+            config["remove_torrent"]
+        )
+        self.builder.get_object("delay_time").set_value(config["delay_time"])
+        self.builder.get_object("default_stop_time").set_value(
+            config["default_stop_time"]
+        )
+
+        # populate filter table
+        self.liststore = Gtk.ListStore(str, str, float)
+        for filter_ref in config["filter_list"]:
+            self.liststore.append(
+                [filter_ref["field"], filter_ref["filter"], filter_ref["stop_time"]]
+            )
+
+        self.treeview.set_model(self.liststore)
+
+    def on_field_changed(self, widget, path, text):
+        self.liststore[path][0] = text
+
+    def on_filter_changed(self, widget, path, text):
+        self.liststore[path][1] = text
+
+    def on_stoptime_edited(self, widget, path, value):
+        self.liststore[path][2] = float(value)
+
+    def btnAddCallback(self, widget):
+        self.liststore.prepend(["label", "RegEx", 3.0])
+
+    def btnRemoveCallback(self, widget):
+        selection = self.treeview.get_selection()
+        model, paths = selection.get_selected_rows()
+
+        # Get the TreeIter instance for each path
+        for path in paths:
+            itr = model.get_iter(path)
+            model.remove(itr)
+
+    def btnUpCallback(self, widget):
+        selection = self.treeview.get_selection()
+        model, paths = selection.get_selected_rows()
+
+        for path in paths:
+            itr = model.get_iter(path)
+            if path[0] > 0:
+                previousRow = model.get_iter(path[0] - 1)
+                model.move_before(itr, previousRow)
+
+    def btnDownCallback(self, widget):
+        selection = self.treeview.get_selection()
+        model, paths = selection.get_selected_rows()
+
+        for path in paths:
+            itr = model.get_iter(path)
+            if path[0] < len(model) - 1:
+                nextRow = model.get_iter(path[0] + 1)
+                model.move_after(itr, nextRow)
+
+
+class SeedTimeMenu(Gtk.MenuItem):
+    def __init__(self):
+        Gtk.MenuItem.__init__(self, "Seed Stop Time")
+
+        self.sub_menu = Gtk.Menu()
+        self.set_submenu(self.sub_menu)
+        self.items = []
+
+        # attach..
+        self.sub_menu.connect("show", self.on_show, None)
+
+    def get_torrent_ids(self):
+        return component.get("TorrentView").get_selected_torrents()
+
+    def on_show(self, widget=None, data=None):
+        try:
+            for child in self.sub_menu.get_children():
+                self.sub_menu.remove(child)
+            # TODO: Make thise times customizable, and/or add a custom popup
+            for time in (None, 1, 2, 3, 7, 14, 30):
+                if time is None:
+                    item = Gtk.MenuItem("Never")
+                else:
+                    item = Gtk.MenuItem(str(time) + " days")
+                item.connect("activate", self.on_select_time, time)
+                self.sub_menu.append(item)
+            item = Gtk.MenuItem("Custom")
+            item.connect("activate", self.on_custom_time)
+            self.sub_menu.append(item)
+            self.show_all()
+        except Exception as e:
+            log.exception("AHH!")
+
+    def on_select_time(self, widget=None, time=None):
+        log.debug("select seed stop time:%s,%s" % (time, self.get_torrent_ids()))
+        for torrent_id in self.get_torrent_ids():
+            client.seedtime.set_torrent(torrent_id, time)
+
+    def on_custom_time(self, widget=None):
+        # Show the custom time dialog
+        builder = Gtk.Builder()
+        builder.add_from_file(get_resource("dialog.ui"))
+        dlg = builder.get_object("dlg_custom_time")
+        result = dlg.run()
+        if result == Gtk.RESPONSE_OK:
+            time = builder.get_object("txt_custom_stop_time").get_text()
+            try:
+                self.on_select_time(time=float(time))
+            except ValueError:
+                log.error("Invalid custom stop time entered.")
+        dlg.destroy()

--- a/deluge_seedtime/gtkui.py
+++ b/deluge_seedtime/gtkui.py
@@ -44,26 +44,43 @@ from deluge.log import LOG as log
 from deluge.ui.client import client
 from deluge.plugins.pluginbase import GtkPluginBase
 import deluge.component as component
-try:
-    from deluge.ui.gtkui.listview import cell_data_time
-except ImportError:
-    from deluge.ui.gtkui.torrentview_data_funcs import cell_data_time
 
-from common import get_resource
+try:
+    from deluge.ui.gtk3.listview import cell_data_time
+except ImportError:
+    from deluge.ui.gtk3.torrentview_data_funcs import cell_data_time
+
+from .common import get_resource
 
 
 class GtkUI(GtkPluginBase):
     def enable(self):
-        self.glade = gtk.glade.XML(get_resource("config.glade"))
+        self.builder = gtk.Builder()
+        self.builder.add_from_file(get_resource("config.ui"))
 
-        component.get("Preferences").add_page("SeedTime", self.glade.get_widget("prefs_box"))
-        component.get("PluginManager").register_hook("on_apply_prefs", self.on_apply_prefs)
-        component.get("PluginManager").register_hook("on_show_prefs", self.on_show_prefs)
+        component.get("Preferences").add_page(
+            "SeedTime", self.builder.get_object("prefs_box")
+        )
+        component.get("PluginManager").register_hook(
+            "on_apply_prefs", self.on_apply_prefs
+        )
+        component.get("PluginManager").register_hook(
+            "on_show_prefs", self.on_show_prefs
+        )
         # Columns
         torrentview = component.get("TorrentView")
-        torrentview.add_func_column(_("Seed Time"), cell_data_time, [int], status_field=["seeding_time"])
-        torrentview.add_func_column(_("Stop Seed Time"), cell_data_time, [int], status_field=["seed_stop_time"])
-        torrentview.add_func_column(_("Remaining Seed Time"), cell_data_time, [int], status_field=["seed_time_remaining"])
+        torrentview.add_func_column(
+            _("Seed Time"), cell_data_time, [int], status_field=["seeding_time"]
+        )
+        torrentview.add_func_column(
+            _("Stop Seed Time"), cell_data_time, [int], status_field=["seed_stop_time"]
+        )
+        torrentview.add_func_column(
+            _("Remaining Seed Time"),
+            cell_data_time,
+            [int],
+            status_field=["seed_time_remaining"],
+        )
         # Submenu
         log.debug("add items to torrentview-popup menu.")
         torrentmenu = component.get("MenuBar").torrentmenu
@@ -76,18 +93,18 @@ class GtkUI(GtkPluginBase):
 
     def setupFilterTable(self):
         # Setup filter button callbacks
-        self.btnAdd = self.glade.get_widget("btnAdd")
+        self.btnAdd = self.builder.get_object("btnAdd")
         self.btnAdd.connect("clicked", self.btnAddCallback)
-        self.btnRemove = self.glade.get_widget("btnRemove")
+        self.btnRemove = self.builder.get_object("btnRemove")
         self.btnRemove.connect("clicked", self.btnRemoveCallback)
-        self.btnUp = self.glade.get_widget("btnUp")
+        self.btnUp = self.builder.get_object("btnUp")
         self.btnUp.connect("clicked", self.btnUpCallback)
-        self.btnDown = self.glade.get_widget("btnDown")
+        self.btnDown = self.builder.get_object("btnDown")
         self.btnDown.connect("clicked", self.btnDownCallback)
 
         # cell by cell renderer callback, changes field and filter to editable
         def rowRendererCb(column, cell, model, itr):
-            cell.set_property('editable', True)
+            cell.set_property("editable", True)
 
         # creating the treeview,and add columns
         self.treeview = gtk.TreeView()
@@ -135,18 +152,25 @@ class GtkUI(GtkPluginBase):
         column.set_widget(label)
         label.show()
         tooltips = Tooltips()
-        tooltips.set_tip(label, "Set the amount of time a torrent seeds for "
-                                "before being stopped. Default value is editable")
+        tooltips.set_tip(
+            label,
+            "Set the amount of time a torrent seeds for "
+            "before being stopped. Default value is editable",
+        )
         self.treeview.append_column(column)
 
-        self.sw1 = self.glade.get_widget('scrolledwindow1')
+        self.sw1 = self.builder.get_object("scrolledwindow1")
         self.sw1.add(self.treeview)
         self.sw1.show_all()
 
     def disable(self):
         component.get("Preferences").remove_page("SeedTime")
-        component.get("PluginManager").deregister_hook("on_apply_prefs", self.on_apply_prefs)
-        component.get("PluginManager").deregister_hook("on_show_prefs", self.on_show_prefs)
+        component.get("PluginManager").deregister_hook(
+            "on_apply_prefs", self.on_apply_prefs
+        )
+        component.get("PluginManager").deregister_hook(
+            "on_show_prefs", self.on_show_prefs
+        )
         try:
             # Columns
             component.get("TorrentView").remove_column(_("Seed Time"))
@@ -155,17 +179,24 @@ class GtkUI(GtkPluginBase):
             # Submenu
             torrentmenu = component.get("MenuBar").torrentmenu
             torrentmenu.remove(self.seedtime_menu)
-        except Exception, e:
+        except Exception as e:
             log.debug(e)
 
     def on_apply_prefs(self):
         log.debug("applying prefs for SeedTime")
 
         config = {
-            "remove_torrent": self.glade.get_widget("chk_remove_torrent").get_active(),
-            "filter_list": list({'field': row[0], 'filter': row[1], 'stop_time': row[2]} for row in self.liststore),
-            "delay_time": self.glade.get_widget("delay_time").get_value_as_int(),
-            "default_stop_time": self.glade.get_widget("default_stop_time").get_value(),
+            "remove_torrent": self.builder.get_object(
+                "chk_remove_torrent"
+            ).get_active(),
+            "filter_list": list(
+                {"field": row[0], "filter": row[1], "stop_time": row[2]}
+                for row in self.liststore
+            ),
+            "delay_time": self.builder.get_object("delay_time").get_value_as_int(),
+            "default_stop_time": self.builder.get_object(
+                "default_stop_time"
+            ).get_value(),
         }
         client.seedtime.set_config(config)
 
@@ -174,15 +205,21 @@ class GtkUI(GtkPluginBase):
 
     def cb_get_config(self, config):
         """callback for on show_prefs"""
-        log.debug('cb get config seedtime')
-        self.glade.get_widget("chk_remove_torrent").set_active(config["remove_torrent"])
-        self.glade.get_widget("delay_time").set_value(config["delay_time"])
-        self.glade.get_widget("default_stop_time").set_value(config["default_stop_time"])
+        log.debug("cb get config seedtime")
+        self.builder.get_object("chk_remove_torrent").set_active(
+            config["remove_torrent"]
+        )
+        self.builder.get_object("delay_time").set_value(config["delay_time"])
+        self.builder.get_object("default_stop_time").set_value(
+            config["default_stop_time"]
+        )
 
         # populate filter table
         self.liststore = gtk.ListStore(str, str, float)
-        for filter_ref in config['filter_list']:
-            self.liststore.append([filter_ref['field'], filter_ref['filter'], filter_ref['stop_time']])
+        for filter_ref in config["filter_list"]:
+            self.liststore.append(
+                [filter_ref["field"], filter_ref["filter"], filter_ref["stop_time"]]
+            )
 
         self.treeview.set_model(self.liststore)
 
@@ -214,7 +251,7 @@ class GtkUI(GtkPluginBase):
         for path in paths:
             itr = model.get_iter(path)
             if path[0] > 0:
-                previousRow = model.get_iter(path[0]-1)
+                previousRow = model.get_iter(path[0] - 1)
                 model.move_before(itr, previousRow)
 
     def btnDownCallback(self, widget):
@@ -223,9 +260,10 @@ class GtkUI(GtkPluginBase):
 
         for path in paths:
             itr = model.get_iter(path)
-            if path[0] < len(model)-1:
-                nextRow = model.get_iter(path[0]+1)
+            if path[0] < len(model) - 1:
+                nextRow = model.get_iter(path[0] + 1)
                 model.move_after(itr, nextRow)
+
 
 class SeedTimeMenu(gtk.MenuItem):
     def __init__(self):
@@ -235,7 +273,7 @@ class SeedTimeMenu(gtk.MenuItem):
         self.set_submenu(self.sub_menu)
         self.items = []
 
-        #attach..
+        # attach..
         torrentmenu = component.get("MenuBar").torrentmenu
         self.sub_menu.connect("show", self.on_show, None)
 
@@ -249,32 +287,33 @@ class SeedTimeMenu(gtk.MenuItem):
             # TODO: Make thise times customizable, and/or add a custom popup
             for time in (None, 1, 2, 3, 7, 14, 30):
                 if time is None:
-                    item = gtk.MenuItem('Never')
+                    item = gtk.MenuItem("Never")
                 else:
-                    item = gtk.MenuItem(str(time) + ' days')
+                    item = gtk.MenuItem(str(time) + " days")
                 item.connect("activate", self.on_select_time, time)
                 self.sub_menu.append(item)
-            item = gtk.MenuItem('Custom')
-            item.connect('activate', self.on_custom_time)
+            item = gtk.MenuItem("Custom")
+            item.connect("activate", self.on_custom_time)
             self.sub_menu.append(item)
             self.show_all()
-        except Exception, e:
-            log.exception('AHH!')
+        except Exception as e:
+            log.exception("AHH!")
 
     def on_select_time(self, widget=None, time=None):
-        log.debug("select seed stop time:%s,%s" % (time ,self.get_torrent_ids()) )
+        log.debug("select seed stop time:%s,%s" % (time, self.get_torrent_ids()))
         for torrent_id in self.get_torrent_ids():
             client.seedtime.set_torrent(torrent_id, time)
 
     def on_custom_time(self, widget=None):
         # Show the custom time dialog
-        glade = gtk.glade.XML(get_resource("config.glade"))
-        dlg = glade.get_widget('dlg_custom_time')
+        builder = gtk.Builder()
+        builder.add_from_file(get_resource("dialog.ui"))
+        dlg = builder.get_object("dlg_custom_time")
         result = dlg.run()
         if result == gtk.RESPONSE_OK:
-            time = glade.get_widget('txt_custom_stop_time').get_text()
+            time = builder.get_object("txt_custom_stop_time").get_text()
             try:
                 self.on_select_time(time=float(time))
             except ValueError:
-                log.error('Invalid custom stop time entered.')
+                log.error("Invalid custom stop time entered.")
         dlg.destroy()

--- a/deluge_seedtime/webui.py
+++ b/deluge_seedtime/webui.py
@@ -1,5 +1,5 @@
 #
-# common.py
+# webui.py
 #
 # Copyright (C) 2009 Chase Sterling <chase.sterling@gmail.com>
 #
@@ -37,6 +37,23 @@
 #    statement from all source files in the program, then also delete it here.
 #
 
-def get_resource(filename):
-    import pkg_resources, os
-    return pkg_resources.resource_filename("seedtime", os.path.join("data", filename))
+from __future__ import unicode_literals
+
+import logging
+
+from deluge.plugins.pluginbase import WebPluginBase
+
+from .common import get_resource
+
+log = logging.getLogger(__name__)
+
+
+class WebUI(WebPluginBase):
+
+    scripts = [get_resource("seedtime.js")]
+
+    def enable(self):
+        pass
+
+    def disable(self):
+        pass

--- a/seedtime/core.py
+++ b/seedtime/core.py
@@ -47,11 +47,11 @@ import deluge.configmanager
 from deluge.core.rpcserver import export
 
 CONFIG_DEFAULT = {
+    "default_stop_time": 7,
     "remove_torrent": False,
-    "default_stoptime": 1.0,
+    "delay_time": 1,  # delay between adding torrent and setting initial seed time (in seconds)
     "filter_list": [], #example: {'field': 'tracker', 'filter': ".*", 'stop_time': 7.0}],
-    "torrent_stop_times": {},  # torrent_id: stop_time (in hours)
-    "delay_time": 1  # delay between adding torrent and setting initial seed time (in seconds)
+    "torrent_stop_times": {}  # torrent_id: stop_time (in hours)
 }
 
 class Core(CorePluginBase):
@@ -143,6 +143,11 @@ class Core(CorePluginBase):
                     log.debug('applying stop.... time %r' % stop_time)
                     self.set_torrent(torrent_id, stop_time)
                     break  # stop looking through filter list
+        else: #apply default if no filters match
+            stop_time = self.config['default_stop_time']
+            if stop_time > 0:
+                log.debug('applying stop.... time %r' % stop_time)
+                self.set_torrent(torrent_id, stop_time)
 
     def post_torrent_remove(self, torrent_id):
         log.debug("seedtime post_torrent_remove")

--- a/seedtime/core.py
+++ b/seedtime/core.py
@@ -100,8 +100,8 @@ class Core(CorePluginBase):
                     torrent.pause()
 
     ## Plugin hooks ##
-    def post_torrent_add(self, torrent_id):
-        if not self.torrent_manager.session_started:
+    def post_torrent_add(self, torrent_id, from_state=None):
+        if from_state == True or (from_state == None and not self.torrent_manager.session_started):
             return
         log.debug("seedtime post_torrent_add")
 

--- a/seedtime/core.py
+++ b/seedtime/core.py
@@ -48,7 +48,8 @@ from deluge.core.rpcserver import export
 
 CONFIG_DEFAULT = {
     "remove_torrent": False,
-    "filter_list": [{'field': 'default', 'filter': ".*", 'stop_time': 7.0}],
+    "default_stoptime": 1.0,
+    "filter_list": [], #example: {'field': 'tracker', 'filter': ".*", 'stop_time': 7.0}],
     "torrent_stop_times": {},  # torrent_id: stop_time (in hours)
     "delay_time": 1  # delay between adding torrent and setting initial seed time (in seconds)
 }

--- a/seedtime/core.py
+++ b/seedtime/core.py
@@ -164,7 +164,7 @@ class Core(CorePluginBase):
 
     @export
     def set_torrent(self, torrent_id , stop_time):
-        if stop_time is None:
+        if stop_time is None or stop_time < 0:
             del self.torrent_stop_times[torrent_id]
         else:
             self.torrent_stop_times[torrent_id] = stop_time

--- a/seedtime/core.py
+++ b/seedtime/core.py
@@ -64,6 +64,7 @@ class Core(CorePluginBase):
         self.torrent_manager = component.get("TorrentManager")
         self.plugin = component.get("CorePluginManager")
         self.plugin.register_status_field("seed_stop_time", self._status_get_seed_stop_time)
+        self.plugin.register_status_field("seed_time_remaining", self._status_get_remaining_seed_time)
         self.torrent_manager = component.get("TorrentManager")
 
         component.get("EventManager").register_event_handler("TorrentAddedEvent", self.post_torrent_add)
@@ -78,6 +79,7 @@ class Core(CorePluginBase):
 
     def disable(self):
         self.plugin.deregister_status_field("seed_stop_time")
+        self.plugin.deregister_status_field("seed_time_remaining")
         if self.looping_call.running:
             self.looping_call.stop()
 
@@ -171,3 +173,10 @@ class Core(CorePluginBase):
     def _status_get_seed_stop_time(self, torrent_id):
         """Returns the stop seed time for the torrent."""
         return self.torrent_stop_times.get(torrent_id, 0) * 3600.0 * 24.0
+
+    def _status_get_remaining_seed_time(self, torrent_id):
+        """Returns the stop seed time for the torrent."""
+        stop_time = self._status_get_seed_stop_time(torrent_id)
+        torrent = component.get("TorrentManager")[torrent_id]
+        seed_time = torrent.get_status(['seeding_time'])['seeding_time']
+        return max(0, stop_time-seed_time)

--- a/seedtime/data/config.glade
+++ b/seedtime/data/config.glade
@@ -154,7 +154,7 @@
                 <property name="secondary_icon_activatable">False</property>
                 <property name="primary_icon_sensitive">True</property>
                 <property name="secondary_icon_sensitive">True</property>
-                <property name="adjustment">0 0 999 1 10 0</property>
+                <property name="adjustment">0 0 999 0.01 10 0</property>
                 <property name="digits">2</property>
                 <property name="snap_to_ticks">True</property>
                 <property name="numeric">True</property>

--- a/seedtime/data/config.glade
+++ b/seedtime/data/config.glade
@@ -1,33 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glade-interface>
-  <!-- interface-requires gtk+ 2.16 -->
+<interface>
+  <requires lib="gtk+" version="2.16"/>
   <!-- interface-naming-policy toplevel-contextual -->
-  <widget class="GtkDialog" id="dlg_custom_time">
+  <object class="GtkDialog" id="dlg_custom_time">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="modal">True</property>
     <property name="type_hint">normal</property>
     <child internal-child="vbox">
-      <widget class="GtkVBox" id="dialog-vbox1">
+      <object class="GtkVBox" id="dialog-vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <widget class="GtkHButtonBox" id="dialog-action_area1">
+          <object class="GtkHButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <widget class="GtkButton" id="button2">
+              <object class="GtkButton" id="button2">
                 <property name="label">gtk-cancel</property>
-                <property name="response_id">-6</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
                 <property name="yalign">0.49000000953674316</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -35,22 +34,21 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="button1">
+              <object class="GtkButton" id="button1">
                 <property name="label">gtk-ok</property>
-                <property name="response_id">-5</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
@@ -59,16 +57,16 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkHBox" id="hbox1">
+          <object class="GtkHBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <widget class="GtkLabel" id="label1">
+              <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Stop seeding after</property>
                 <property name="justify">right</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
@@ -77,7 +75,7 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkEntry" id="txt_custom_stop_time">
+              <object class="GtkEntry" id="txt_custom_stop_time">
                 <property name="width_request">45</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -87,7 +85,7 @@
                 <property name="secondary_icon_activatable">False</property>
                 <property name="primary_icon_sensitive">True</property>
                 <property name="secondary_icon_sensitive">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
@@ -95,11 +93,11 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkLabel" id="label2">
+              <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">days.</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
@@ -107,24 +105,28 @@
                 <property name="position">2</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-  <widget class="GtkWindow" id="window1">
+    <action-widgets>
+      <action-widget response="-6">button2</action-widget>
+      <action-widget response="-5">button1</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
     <child>
-      <widget class="GtkVBox" id="prefs_box">
+      <object class="GtkVBox" id="prefs_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <widget class="GtkCheckButton" id="chk_remove_torrent">
+          <object class="GtkCheckButton" id="chk_remove_torrent">
             <property name="label" translatable="yes">Remove torrent when stopping</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -132,7 +134,7 @@
             <property name="use_action_appearance">False</property>
             <property name="xalign">0.50999999046325684</property>
             <property name="draw_indicator">True</property>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
@@ -141,23 +143,27 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkHBox" id="hbox1">
+          <object class="GtkHBox" id="hbox2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <widget class="GtkSpinButton" id="delay_time">
+              <object class="GtkSpinButton" id="default_stop_time">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip" translatable="yes">Wait this long after torrent is added before setting initial stop seed time. Gives the user time to setup things such as labels.</property>
+                <property name="has_tooltip">True</property>
+                <property name="tooltip_markup">Wait this long after torrent is added before setting initial stop seed time. Gives the user time to setup things such as labels.</property>
+                <property name="tooltip_text" translatable="yes">Wait this long after torrent is added before setting initial stop seed time. Gives the user time to setup things such as labels.</property>
                 <property name="invisible_char">•</property>
+                <property name="invisible_char_set">True</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="primary_icon_sensitive">True</property>
                 <property name="secondary_icon_sensitive">True</property>
-                <property name="adjustment">1 1 99999 1 10 0</property>
+                <property name="adjustment"/>
+                <property name="digits">2</property>
                 <property name="snap_to_ticks">True</property>
                 <property name="numeric">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -165,19 +171,19 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkLabel" id="delay_time_label">
+              <object class="GtkLabel" id="default_time_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0.05000000074505806</property>
-                <property name="label" translatable="yes">delay (seconds)</property>
-              </widget>
+                <property name="label" translatable="yes">Default stop time (days)</property>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
@@ -185,13 +191,56 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkTable" id="table1">
+          <object class="GtkHBox" id="hbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkSpinButton" id="delay_time">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="invisible_char">•</property>
+                <property name="primary_icon_activatable">False</property>
+                <property name="secondary_icon_activatable">False</property>
+                <property name="primary_icon_sensitive">True</property>
+                <property name="secondary_icon_sensitive">True</property>
+                <property name="adjustment"/>
+                <property name="snap_to_ticks">True</property>
+                <property name="numeric">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="delay_time_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0.05000000074505806</property>
+                <property name="label" translatable="yes">delay (seconds)</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkTable" id="table1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="n_rows">5</property>
             <property name="n_columns">2</property>
             <child>
-              <widget class="GtkScrolledWindow" id="scrolledwindow1">
+              <object class="GtkScrolledWindow" id="scrolledwindow1">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="hscrollbar_policy">automatic</property>
@@ -199,20 +248,20 @@
                 <child>
                   <placeholder/>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="bottom_attach">5</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnUp">
+              <object class="GtkButton" id="btnUp">
                 <property name="label">gtk-go-up</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -223,14 +272,14 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnDown">
+              <object class="GtkButton" id="btnDown">
                 <property name="label">gtk-go-down</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -241,14 +290,14 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnAdd">
+              <object class="GtkButton" id="btnAdd">
                 <property name="label">gtk-add</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -257,14 +306,14 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnRemove">
+              <object class="GtkButton" id="btnRemove">
                 <property name="label">gtk-remove</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -275,10 +324,10 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkLabel" id="label1">
+              <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -287,14 +336,14 @@
                 <property name="x_options">GTK_SHRINK | GTK_FILL</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+</interface>

--- a/seedtime/data/config.glade
+++ b/seedtime/data/config.glade
@@ -1,32 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<interface>
-  <requires lib="gtk+" version="2.16"/>
+<glade-interface>
+  <!-- interface-requires gtk+ 2.16 -->
   <!-- interface-naming-policy toplevel-contextual -->
-  <object class="GtkDialog" id="dlg_custom_time">
+  <widget class="GtkDialog" id="dlg_custom_time">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="modal">True</property>
     <property name="type_hint">normal</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
+      <widget class="GtkVBox" id="dialog-vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
+          <widget class="GtkHButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="button2">
+              <widget class="GtkButton" id="button2">
                 <property name="label">gtk-cancel</property>
+                <property name="response_id">-6</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
                 <property name="yalign">0.49000000953674316</property>
-              </object>
+              </widget>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -34,21 +35,22 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="button1">
+              <widget class="GtkButton" id="button1">
                 <property name="label">gtk-ok</property>
+                <property name="response_id">-5</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </object>
+              </widget>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </object>
+          </widget>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
@@ -57,16 +59,16 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox1">
+          <widget class="GtkHBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkLabel" id="label1">
+              <widget class="GtkLabel" id="label1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Stop seeding after</property>
                 <property name="justify">right</property>
-              </object>
+              </widget>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
@@ -75,7 +77,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkEntry" id="txt_custom_stop_time">
+              <widget class="GtkEntry" id="txt_custom_stop_time">
                 <property name="width_request">45</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -85,7 +87,7 @@
                 <property name="secondary_icon_activatable">False</property>
                 <property name="primary_icon_sensitive">True</property>
                 <property name="secondary_icon_sensitive">True</property>
-              </object>
+              </widget>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
@@ -93,11 +95,11 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="label2">
+              <widget class="GtkLabel" id="label2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">days.</property>
-              </object>
+              </widget>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
@@ -105,28 +107,24 @@
                 <property name="position">2</property>
               </packing>
             </child>
-          </object>
+          </widget>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
-      </object>
+      </widget>
     </child>
-    <action-widgets>
-      <action-widget response="-6">button2</action-widget>
-      <action-widget response="-5">button1</action-widget>
-    </action-widgets>
-  </object>
-  <object class="GtkWindow" id="window1">
+  </widget>
+  <widget class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
     <child>
-      <object class="GtkVBox" id="prefs_box">
+      <widget class="GtkVBox" id="prefs_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <object class="GtkCheckButton" id="chk_remove_torrent">
+          <widget class="GtkCheckButton" id="chk_remove_torrent">
             <property name="label" translatable="yes">Remove torrent when stopping</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -134,7 +132,7 @@
             <property name="use_action_appearance">False</property>
             <property name="xalign">0.50999999046325684</property>
             <property name="draw_indicator">True</property>
-          </object>
+          </widget>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
@@ -143,27 +141,24 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox2">
+          <widget class="GtkHBox" id="hbox2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkSpinButton" id="default_stop_time">
+              <widget class="GtkSpinButton" id="default_stop_time">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip_markup">Wait this long after torrent is added before setting initial stop seed time. Gives the user time to setup things such as labels.</property>
-                <property name="tooltip_text" translatable="yes">Wait this long after torrent is added before setting initial stop seed time. Gives the user time to setup things such as labels.</property>
+                <property name="tooltip" translatable="yes">Default stop seed time if no filter matches. Default time of 0 means infinite seed time.</property>
                 <property name="invisible_char">•</property>
-                <property name="invisible_char_set">True</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="primary_icon_sensitive">True</property>
                 <property name="secondary_icon_sensitive">True</property>
-                <property name="adjustment"/>
+                <property name="adjustment">0 0 999 1 10 0</property>
                 <property name="digits">2</property>
                 <property name="snap_to_ticks">True</property>
                 <property name="numeric">True</property>
-              </object>
+              </widget>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -171,19 +166,19 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="default_time_label">
+              <widget class="GtkLabel" id="default_time_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0.05000000074505806</property>
                 <property name="label" translatable="yes">Default stop time (days)</property>
-              </object>
+              </widget>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </object>
+          </widget>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
@@ -191,22 +186,23 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox1">
+          <widget class="GtkHBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkSpinButton" id="delay_time">
+              <widget class="GtkSpinButton" id="delay_time">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="tooltip" translatable="yes">Wait this long after torrent is added before setting initial stop seed time. Gives the user time to setup things such as labels.</property>
                 <property name="invisible_char">•</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="primary_icon_sensitive">True</property>
                 <property name="secondary_icon_sensitive">True</property>
-                <property name="adjustment"/>
+                <property name="adjustment">1 1 99999 1 10 0</property>
                 <property name="snap_to_ticks">True</property>
                 <property name="numeric">True</property>
-              </object>
+              </widget>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -214,19 +210,19 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="delay_time_label">
+              <widget class="GtkLabel" id="delay_time_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0.05000000074505806</property>
                 <property name="label" translatable="yes">delay (seconds)</property>
-              </object>
+              </widget>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </object>
+          </widget>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
@@ -234,13 +230,13 @@
           </packing>
         </child>
         <child>
-          <object class="GtkTable" id="table1">
+          <widget class="GtkTable" id="table1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="n_rows">5</property>
             <property name="n_columns">2</property>
             <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow1">
+              <widget class="GtkScrolledWindow" id="scrolledwindow1">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="hscrollbar_policy">automatic</property>
@@ -248,20 +244,20 @@
                 <child>
                   <placeholder/>
                 </child>
-              </object>
+              </widget>
               <packing>
                 <property name="bottom_attach">5</property>
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="btnUp">
+              <widget class="GtkButton" id="btnUp">
                 <property name="label">gtk-go-up</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </object>
+              </widget>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -272,14 +268,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="btnDown">
+              <widget class="GtkButton" id="btnDown">
                 <property name="label">gtk-go-down</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </object>
+              </widget>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -290,14 +286,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="btnAdd">
+              <widget class="GtkButton" id="btnAdd">
                 <property name="label">gtk-add</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </object>
+              </widget>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -306,14 +302,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="btnRemove">
+              <widget class="GtkButton" id="btnRemove">
                 <property name="label">gtk-remove</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
-              </object>
+              </widget>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -324,10 +320,10 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="label1">
+              <widget class="GtkLabel" id="label1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-              </object>
+              </widget>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="right_attach">2</property>
@@ -336,14 +332,14 @@
                 <property name="x_options">GTK_SHRINK | GTK_FILL</property>
               </packing>
             </child>
-          </object>
+          </widget>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">3</property>
           </packing>
         </child>
-      </object>
+      </widget>
     </child>
-  </object>
-</interface>
+  </widget>
+</glade-interface>

--- a/seedtime/data/config.glade
+++ b/seedtime/data/config.glade
@@ -162,11 +162,12 @@
             </child>
             <child>
               <widget class="GtkButton" id="btnUp">
-                <property name="label" translatable="yes">Up</property>
+                <property name="label">gtk-go-up</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
               </widget>
               <packing>
                 <property name="left_attach">1</property>
@@ -179,11 +180,12 @@
             </child>
             <child>
               <widget class="GtkButton" id="btnDown">
-                <property name="label" translatable="yes">Down</property>
+                <property name="label">gtk-go-down</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
               </widget>
               <packing>
                 <property name="left_attach">1</property>
@@ -196,11 +198,12 @@
             </child>
             <child>
               <widget class="GtkButton" id="btnAdd">
-                <property name="label" translatable="yes">Add</property>
+                <property name="label">gtk-add</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
               </widget>
               <packing>
                 <property name="left_attach">1</property>
@@ -211,11 +214,12 @@
             </child>
             <child>
               <widget class="GtkButton" id="btnRemove">
-                <property name="label" translatable="yes">Remove</property>
+                <property name="label">gtk-remove</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
               </widget>
               <packing>
                 <property name="left_attach">1</property>

--- a/seedtime/data/config.glade
+++ b/seedtime/data/config.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glade-interface>
-  <!-- interface-requires gtk+ 2.6 -->
+  <!-- interface-requires gtk+ 2.16 -->
   <!-- interface-naming-policy toplevel-contextual -->
   <widget class="GtkDialog" id="dlg_custom_time">
     <property name="can_focus">False</property>
@@ -24,6 +24,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
                 <property name="yalign">0.49000000953674316</property>
               </widget>
@@ -40,6 +41,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </widget>
               <packing>
@@ -122,54 +124,14 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <widget class="GtkHBox" id="hbox1">
+          <widget class="GtkCheckButton" id="chk_remove_torrent">
+            <property name="label" translatable="yes">Remove torrent when stopping</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <widget class="GtkCheckButton" id="chk_apply_stop_time">
-                <property name="label" translatable="yes">Stop after seeding</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="draw_indicator">True</property>
-              </widget>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkEntry" id="txt_default_stop_time">
-                <property name="width_request">50</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="invisible_char">●</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-                <signal name="editing_done" handler="on_edit_done" swapped="no"/>
-              </widget>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="padding">5</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkLabel" id="label3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">days   (applies to all new torrents)</property>
-              </widget>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="use_action_appearance">False</property>
+            <property name="xalign">0.50999999046325684</property>
+            <property name="draw_indicator">True</property>
           </widget>
           <packing>
             <property name="expand">False</property>
@@ -179,31 +141,109 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkCheckButton" id="chk_remove_torrent">
-            <property name="label" translatable="yes">Remove torrent when stopping</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="xalign">0.50999999046325684</property>
-            <property name="draw_indicator">True</property>
-          </widget>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="padding">3</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <widget class="GtkLabel" id="lbl_error">
+          <widget class="GtkTable" id="table1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="xalign">0.52999997138977051</property>
+            <property name="n_rows">5</property>
+            <property name="n_columns">2</property>
+            <child>
+              <widget class="GtkScrolledWindow" id="scrolledwindow1">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hscrollbar_policy">automatic</property>
+                <property name="vscrollbar_policy">automatic</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </widget>
+              <packing>
+                <property name="bottom_attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkButton" id="btnUp">
+                <property name="label" translatable="yes">Up</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+              </widget>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">2</property>
+                <property name="bottom_attach">3</property>
+                <property name="x_options">GTK_SHRINK | GTK_FILL</property>
+                <property name="y_options">GTK_SHRINK</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkButton" id="btnDown">
+                <property name="label" translatable="yes">Down</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+              </widget>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">3</property>
+                <property name="bottom_attach">4</property>
+                <property name="x_options">GTK_SHRINK | GTK_FILL</property>
+                <property name="y_options">GTK_SHRINK</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkButton" id="btnAdd">
+                <property name="label" translatable="yes">Add</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+              </widget>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="right_attach">2</property>
+                <property name="x_options">GTK_SHRINK | GTK_FILL</property>
+                <property name="y_options">GTK_SHRINK</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkButton" id="btnRemove">
+                <property name="label" translatable="yes">Remove</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+              </widget>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">1</property>
+                <property name="bottom_attach">2</property>
+                <property name="x_options">GTK_SHRINK | GTK_FILL</property>
+                <property name="y_options">GTK_SHRINK</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </widget>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">4</property>
+                <property name="bottom_attach">5</property>
+                <property name="x_options">GTK_SHRINK | GTK_FILL</property>
+              </packing>
+            </child>
           </widget>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </widget>

--- a/seedtime/data/config.glade
+++ b/seedtime/data/config.glade
@@ -141,6 +141,50 @@
           </packing>
         </child>
         <child>
+          <widget class="GtkHBox" id="hbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <widget class="GtkSpinButton" id="delay_time">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip" translatable="yes">Wait this long after torrent is added before setting initial stop seed time. Gives the user time to setup things such as labels.</property>
+                <property name="invisible_char">•</property>
+                <property name="primary_icon_activatable">False</property>
+                <property name="secondary_icon_activatable">False</property>
+                <property name="primary_icon_sensitive">True</property>
+                <property name="secondary_icon_sensitive">True</property>
+                <property name="adjustment">1 1 99999 1 10 0</property>
+                <property name="snap_to_ticks">True</property>
+                <property name="numeric">True</property>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkLabel" id="delay_time_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0.05000000074505806</property>
+                <property name="label" translatable="yes">delay (seconds)</property>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </widget>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
           <widget class="GtkTable" id="table1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -247,7 +291,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </widget>

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -31,6 +31,19 @@ Copyright:
     statement from all source files in the program, then also delete it here.
 */
 
+// TODO: reorder grid
+// TODO: remove item from grid
+// TODO: edit item in grid
+// TODO: make sure default is handled correctly
+// TODO: load data to grid
+// TODO: save data from grid
+// TODO: fix layout, grid not expanding
+// TODO: layout, move buttons?
+// TODO: add min/max to stop time coloumn
+// TODO: make sure stoptime coloumn is rendered as number
+// TODO: clean up: fix formatting
+// TODO: clean up: probably lots of unneeded code
+
 Ext.ns('Deluge.ux');
 
 Ext.ns('Deluge.ux.preferences');
@@ -45,18 +58,24 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
     initComponent: function() {
         Deluge.ux.preferences.SeedTimePage.superclass.initComponent.call(this);
 
+        // this.vbox = this.add({
+        //     xtype: 'container',
+        //     layout: 'vbox',
+        //     defaultType: 'button'
+        //   });
+
         this.form = this.add({
             xtype: 'form',
             layout: 'form',
             border: false,
-            autoHeight: true
+            // autoHeight: true
         });
 
         this.settings = this.form.add({
           xtype : 'fieldset',
           border : false,
           title : _('Settings'),
-          autoHeight : true,
+          // autoHeight : true,
           defaultType : 'spinnerfield',
           defaults : {minValue : -1, maxValue : 99999},
           style : 'margin-top: 5px; margin-bottom: 0px; padding-bottom: 0px;',
@@ -83,6 +102,8 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         });
 
         this.filter_list = new Ext.grid.GridPanel({
+          autoHeight : true,
+          // autoScroll: true,
           store : new Ext.data.JsonStore({
             fields : [
               {name : 'field', type : 'string'},
@@ -123,44 +144,21 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
           viewConfig : {
             forceFit : true,
           },
-          sm : new Ext.grid.RowSelectionModel({singleSelect : true}),
+          selModel : new Ext.grid.RowSelectionModel({singleSelect : true}),
         });
 
         this.filter_list.getStore().loadData( [
-            { field : "label", filter : "a.*sdf", stoptime : 5.5},
-            { field : "tracker", filter : "asev", stoptime : 6.5} ] );
+            { field : "label", filter : "a.*sdf", stoptime : 1.5},
+            { field : "tracker", filter : "b.*sdf", stoptime : 2.5},
+            { field : "label", filter : "c.*sdf", stoptime : 3.5},
+            { field : "label", filter : "c.*sdf", stoptime : 4.5},
+            { field : "default", filter : ".*", stoptime : 5.5} ] );
 
-        this.add(this.filter_list);
-
-        this.add({
-            xtype: 'container',
-            layout: 'hbox',
-            defaultType: 'button',
-            items: [{
-                itemId: 'up',
-                text: 'Up',
-                scope: this,
-                handler: this.filterUp
-            }, {
-                itemId: 'Down',
-                // margin: '0 0 0 10',
-                text: 'Down',
-                scope: this,
-                handler: this.filterDown
-            }, {
-                itemId: 'add',
-                // margin: '0 0 0 10',
-                text: 'Add',
-                scope: this,
-                handler: this.filterAdd
-            }, {
-                itemId: 'remove',
-                // margin: '0 0 0 10',
-                text: 'Remove',
-                scope: this,
-                handler: this.filterRemove
-            }]
-            });
+        this.filter_list.addButton({text:"Up"},this.filterUp, this);
+        this.filter_list.addButton({text:"Down"},this.filterDown, this);
+        this.filter_list.addButton({text:"Add"},this.filterAdd, this);
+        this.filter_list.addButton({text:"Remove"},this.filterRemove, this);
+        this.form.add(this.filter_list);
 
         this.removeWhenStopped = this.settings.items.get("rm_torrent_checkbox");
         this.delayTime = this.settings.items.get("torrent_delay");
@@ -188,6 +186,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         this.form.layout = new Ext.layout.FormLayout();
         this.form.layout.setContainer(this);
         this.form.doLayout();
+        // this.vbox.doLayout();
     },
 
     onApply: function() {

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -32,6 +32,8 @@ Copyright:
 */
 
 // TODO: move default to field, in gtk too
+// TODO: tooltip about default setting to zero to disable
+// TODO: add tooltips
 // TODO: disable editing of default filter cell
 // TODO: fix perferance page layout, filter list grid automatic height
 // TODO: fix perferance page layout, resize buttons
@@ -86,6 +88,16 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
               maxValue : 300,
               decimalPrecision : 0,
               id : 'torrent_delay'
+            },
+            {
+              fieldLabel : _('Default stop time (days)'),
+              name : 'default_time',
+              width : 80,
+              value : 30,
+              minValue : 0,
+              maxValue : 999,
+              decimalPrecision : 2,
+              id : 'default_stoptime'
             }
           ]
         });
@@ -159,6 +171,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         this.filter_list.addButton({text:"Remove", iconCls: 'icon-remove'}, this.filterRemove, this);
         this.form.add(this.filter_list);
 
+        this.defaultStoptime = this.settings.items.get("default_stoptime");
         this.removeWhenStopped = this.settings.items.get("rm_torrent_checkbox");
         this.delayTime = this.settings.items.get("torrent_delay");
         this.on('show', this.updateConfig, this);
@@ -170,7 +183,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         var selected_rec = sm.getSelected();
         var selected_indx = store.indexOf(selected_rec);
 
-        if (selected_indx > 0 && selected_indx < store.getCount()-1 ) {
+        if (selected_indx > 0 ) {
           store.remove(selected_rec);
           store.insert(selected_indx-1, selected_rec);
           sm.selectRow(selected_indx-1);
@@ -183,7 +196,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         var selected_rec = sm.getSelected();
         var selected_indx = store.indexOf(selected_rec);
 
-        if (selected_indx < store.getCount()-2 ) {
+        if (selected_indx < store.getCount()-1 ) {
           store.remove(selected_rec);
           store.insert(selected_indx+1, selected_rec);
           sm.selectRow(selected_indx+1);
@@ -196,15 +209,9 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
     },
 
     filterRemove: function() {
-      var store = this.filter_list.getStore();
         var store = this.filter_list.getStore();
-        var sm = this.filter_list.getSelectionModel();
-        var selected_rec = sm.getSelected();
-        var selected_indx = store.indexOf(selected_rec);
-
-        if (selected_indx < store.getCount()-1 ) {
-          store.remove(selected_rec);
-        }
+        var selected_rec = this.filter_list.getSelectionModel().getSelected();
+        store.remove(selected_rec);
     },
 
     onRender: function(ct, position) {
@@ -227,7 +234,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
             config['remove_torrent'] = this.removeWhenStopped.getValue();
             config['filter_list'] = filter_items;
             config['delay_time'] = this.delayTime.getValue();
-
+            config['default_stoptime'] = this.defaultStoptime.getValue();
             deluge.client.seedtime.set_config(config);
         }
     },
@@ -242,6 +249,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
                 this.removeWhenStopped.setValue(config['remove_torrent']);
                 this.filter_list.getStore().loadData(config['filter_list']);
                 this.delayTime.setValue(config['delay_time']);
+                this.defaultStoptime.setValue(config['default_stoptime']);
                 this.hasReadConfig = true;
             },
             scope: this

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -31,7 +31,7 @@ Copyright:
     statement from all source files in the program, then also delete it here.
 */
 
-// TODO: return correct field value, (currently always returns tracker)
+// TODO: move default to field, in gtk too
 // TODO: disable editing of default filter cell
 // TODO: fix perferance page layout, filter list grid automatic height
 // TODO: fix perferance page layout, resize buttons
@@ -89,6 +89,29 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
             }
           ]
         });
+        
+        // create reusable renderer
+        Ext.util.Format.comboRenderer = function(combo){
+            return function(value){
+                var record = combo.findRecord(combo.valueField, value);
+                return record ? record.get(combo.displayField) : combo.valueNotFoundText;
+            }
+        };
+        
+        // create the combo instance
+        var combo = new Ext.form.ComboBox({
+            editable:false,
+            triggerAction: 'all',
+            lazyRender:true,
+            mode: 'local',
+            store: new Ext.data.ArrayStore({
+                id: 0,
+                fields: ['myId', 'displayText'],
+                data: [[1, 'label'], [2, 'tracker']]
+            }),
+            valueField: 'displayText',
+            displayField: 'displayText'
+        });
 
         this.filter_list = new Ext.grid.EditorGridPanel({
           height: 300,  //TODO: instead of hard coding, expand height automatically
@@ -109,17 +132,8 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
                 width : .24,
                 sortable : false,
                 dataIndex : 'field',
-                renderer : function(val) {
-                  if (val === "default") {
-                      return 'default';
-                  }
-                  else if (val === "label") {
-                      return '<select><option value="label" selected="selected">label</option><option value="tracker">tracker</option></select>';
-                  }
-                  else {
-                      return '<select><option value="label">label</option><option value="tracker" selected="selected">tracker</option></select>';
-                  }
-                },
+                editor : combo,
+                renderer : Ext.util.Format.comboRenderer(combo),
               },
               { header : 'Filter',
                 width : .50,

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -52,29 +52,24 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
     border: false,
     title: _('SeedTime'),
     header: false,
-    layout: 'fit',
+    layout: {
+        type: 'vbox',
+        align: 'stretch'
+    },
 
     initComponent: function() {
         Deluge.ux.preferences.SeedTimePage.superclass.initComponent.call(this);
-
-        // this.vbox = this.add({
-        //     xtype: 'container',
-        //     layout: 'vbox',
-        //     defaultType: 'button'
-        //   });
 
         this.form = this.add({
             xtype: 'form',
             layout: 'form',
             border: false,
-            // autoHeight: true
         });
 
         this.settings = this.form.add({
           xtype : 'fieldset',
           border : false,
           title : _('Settings'),
-          // autoHeight : true,
           defaultType : 'spinnerfield',
           defaults : {minValue : -1, maxValue : 99999},
           style : 'margin-top: 5px; margin-bottom: 0px; padding-bottom: 0px;',
@@ -100,9 +95,9 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
           ]
         });
 
-        this.filter_list = new Ext.grid.GridPanel({
-          autoHeight : true,
-          // autoScroll: true,
+        this.filter_list = new Ext.grid.EditorGridPanel({
+          height: 300,  //TODO: instead, expand height automatically
+          flex: 1,
           store : new Ext.data.JsonStore({
             fields : [
               {name : 'field', type : 'string'},
@@ -131,30 +126,16 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
                   }
                 },
               },
-              {header : 'Filter', width : .50, dataIndex : 'filter'},
-              {header : 'Stop Seed Time (days)',
+              { header : 'Filter', width : .50, dataIndex : 'filter',xtype: 'gridcolumn',},
+              { xtype: 'numbercolumn',
+                header : 'Stop Seed Time (days)',
                 width : .26,
                 // renderer : Ext.util.Format.number,
                 dataIndex : 'stoptime'
               },
             ]
           }),
-          flex: 1,
-          viewConfig : {
-            forceFit : true,
-              // plugins: {
-              //     ptype: 'Ext.dd.gridviewdragdrop',
-              //     // ptype: 'gridviewdragdrop',
-              //     dragGroup: 'firstGridDDGroup',
-              //     dropGroup: 'firstGridDDGroup'
-              // },
-              // listeners: {
-              //     drop: function(node, data, dropRec, dropPosition) {
-              //         var dropOn = dropRec ? ' ' + dropPosition + ' ' + dropRec.get('name') : ' on empty view';
-              //         console.log("Drag from right to left", 'Dropped ' + data.records[0].get('name') + dropOn);
-              //     }
-              // }
-          },
+          viewConfig : {forceFit : true},
           selModel : new Ext.grid.RowSelectionModel({singleSelect : true}),
         });
 

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -65,7 +65,14 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
           labelWidth : 200,
           items : [
             {
-              fieldLabel : _('delay (seconds)'),
+              xtype : "checkbox",
+              fieldLabel : 'Remove torrent when stopping',
+              name : 'chk_remove_torrent',
+              checked : true,
+              id : 'rm_torrent_checkbox'
+            },
+            {
+              fieldLabel : _('Delay (seconds)'),
               name : 'delay_time',
               width : 80,
               value : 30,
@@ -73,16 +80,46 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
               maxValue : 300,
               decimalPrecision : 0,
               id : 'torrent_delay'
-            },
-            {
-              xtype : "checkbox",
-              fieldLabel : 'Remove torrent when stopping',
-              name : 'chk_remove_torrent',
-              checked : true,
-              id : 'rm_torrent_checkbox'
             }
           ]
         });
+
+        this.filter_list = new Ext.grid.GridPanel({
+            store: new Ext.data.ArrayStore({
+                fields: [
+                    {name: 'field', type: 'string'},
+                    {name: 'filter', type: 'string'},
+                    {name: 'stoptime', type: 'float'}
+                ],
+                id: 0
+            }),
+            colModel: new Ext.grid.ColumnModel({
+                defaults: {
+                    sortable: false,
+                    menuDisabled: true
+                },
+                columns: [{
+                    header: _('Field'),
+                    width: .24,
+                    dataIndex: 'field'
+                }, {
+                    header: _('Filter'),
+                    width: .50,
+                    dataIndex: 'filter'
+                }, {
+                    header: _('Stop Seed Time (days)'),
+                    width: .26,
+                    renderer: Ext.util.Format.number,
+                    dataIndex: 'stoptime'
+                }]
+            }),
+            viewConfig: {
+                forceFit: true,
+            },
+            sm: new Ext.grid.RowSelectionModel({singleSelect:true}),
+        });
+
+        this.add(this.filter_list)
 
         this.removeWhenStopped = this.settings.items.get("rm_torrent_checkbox");
         this.delayTime = this.settings.items.get("torrent_delay");

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -369,10 +369,12 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
         
         ftimewithnull = function(n) {
                 if(n==null) {return "";}
-                else {return ftime(n);}
+                else if(n == 0) {n=0.1} // avoid 0 being infinite
+                return Deluge.Formatters.timeRemaining(n);
             };
         // status columns
-        this.registerTorrentStatus('seeding_time', _('Seed Time'));
+        this.registerTorrentStatus('seeding_time', _('Seed Time'),
+            { colCfg : { sortable : true, renderer : ftimewithnull}});
         this.registerTorrentStatus('seed_stop_time', _('Stop Seed Time'),
             { colCfg : { sortable : true, renderer : ftimewithnull}});
         this.registerTorrentStatus('seed_time_remaining', _('Remaining Seed Time'),

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -91,17 +91,17 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
             },
             {
               fieldLabel : _('Default stop time (days)'),
-              name : 'default_time',
+              name : 'default_stop_time',
               width : 80,
               value : 30,
               minValue : 0,
               maxValue : 999,
               decimalPrecision : 2,
-              id : 'default_stoptime'
+              id : 'default_stop_time'
             }
           ]
         });
-        
+
         // create reusable renderer
         Ext.util.Format.comboRenderer = function(combo){
             return function(value){
@@ -109,7 +109,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
                 return record ? record.get(combo.displayField) : combo.valueNotFoundText;
             }
         };
-        
+
         // create the combo instance
         var combo = new Ext.form.ComboBox({
             editable:false,
@@ -171,7 +171,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         this.filter_list.addButton({text:"Remove", iconCls: 'icon-remove'}, this.filterRemove, this);
         this.form.add(this.filter_list);
 
-        this.defaultStoptime = this.settings.items.get("default_stoptime");
+        this.defaultStoptime = this.settings.items.get("default_stop_time");
         this.removeWhenStopped = this.settings.items.get("rm_torrent_checkbox");
         this.delayTime = this.settings.items.get("torrent_delay");
         this.on('show', this.updateConfig, this);
@@ -205,7 +205,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
 
     filterAdd: function() {
         var store = this.filter_list.getStore();
-        store.insert(0, new store.recordType({ field : "tracker", filter : ".*", stoptime : 1.0}));
+        store.insert(0, new store.recordType({ field : "label", filter : "RegEx", stoptime : 3.0}));
     },
 
     filterRemove: function() {
@@ -234,7 +234,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
             config['remove_torrent'] = this.removeWhenStopped.getValue();
             config['filter_list'] = filter_items;
             config['delay_time'] = this.delayTime.getValue();
-            config['default_stoptime'] = this.defaultStoptime.getValue();
+            config['default_stop_time'] = this.defaultStoptime.getValue();
             deluge.client.seedtime.set_config(config);
         }
     },
@@ -249,7 +249,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
                 this.removeWhenStopped.setValue(config['remove_torrent']);
                 this.filter_list.getStore().loadData(config['filter_list']);
                 this.delayTime.setValue(config['delay_time']);
-                this.defaultStoptime.setValue(config['default_stoptime']);
+                this.defaultStoptime.setValue(config['default_stop_time']);
                 this.hasReadConfig = true;
             },
             scope: this
@@ -318,7 +318,7 @@ Deluge.ux.CustomSeedtimeWindow = Ext.extend(Ext.Window, {
 SeedTimePlugin = Ext.extend(Deluge.Plugin, {
 
     name: 'SeedTime',
-    
+
     createMenu: function() {
         menuTimes = [1, 2, 3, 7, 14, 30],
         itemslist = [{  text: _('Never'),
@@ -355,7 +355,7 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
             }
         });
     },
-    
+
     setCustomStoptime: function(item, e) {
         if (!this.customTimeWindow) {
             this.customTimeWindow = new Deluge.ux.CustomSeedtimeWindow();
@@ -365,7 +365,7 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
         this.customTimeWindow.e = e;
         this.customTimeWindow.show();
     },
-    
+
     onDisable: function() {
         deluge.preferences.removePage(this.prefsPage);
         deluge.menus.torrent.remove(this.tmSep);
@@ -378,7 +378,7 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
     onEnable: function() {
         //preference page
         this.prefsPage = deluge.preferences.addPage(new Deluge.ux.preferences.SeedTimePage());
-        
+
         //context menu
         this.createMenu();
         this.tmSep = deluge.menus.torrent.add({
@@ -388,7 +388,7 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
             text: _('Seed Stop Time'),
             menu: this.torrentMenu
         });
-        
+
         ftimewithnull = function(n) {
                 if(n==null) {return "";}
                 else if(n == 0) {n=0.1} // avoid 0 being infinite

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -176,7 +176,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
     filterAdd: function() {
         console.log('filterAdd');
         var store = this.filter_list.getStore();
-        store.add(new store.recordType({ field : "tracker", filter : ".*", stoptime : 1.0}));
+        store.insert(0, new store.recordType({ field : "tracker", filter : ".*", stoptime : 1.0}));
     },
     filterRemove: function() {
       var store = this.filter_list.getStore();

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -31,14 +31,11 @@ Copyright:
     statement from all source files in the program, then also delete it here.
 */
 
-// TODO: move default to field, in gtk too
-// TODO: tooltip about default setting to zero to disable
-// TODO: add tooltips
-// TODO: disable editing of default filter cell
+// TODO: gtk not working?
+// TODO: add same tooltips as gtk
 // TODO: fix perferance page layout, filter list grid automatic height
 // TODO: fix perferance page layout, resize buttons
 // TODO: clean up: fix code formatting
-// TODO: clean up: probably lots of unneeded code
 
 Ext.ns('Deluge.ux');
 
@@ -80,16 +77,6 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
               id : 'rm_torrent_checkbox'
             },
             {
-              fieldLabel : _('Delay (seconds)'),
-              name : 'delay_time',
-              width : 80,
-              value : 30,
-              minValue : 1,
-              maxValue : 300,
-              decimalPrecision : 0,
-              id : 'torrent_delay'
-            },
-            {
               fieldLabel : _('Default stop time (days)'),
               name : 'default_stop_time',
               width : 80,
@@ -98,6 +85,16 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
               maxValue : 999,
               decimalPrecision : 2,
               id : 'default_stop_time'
+            },
+            {
+              fieldLabel : _('Delay (seconds)'),
+              name : 'delay_time',
+              width : 80,
+              value : 30,
+              minValue : 1,
+              maxValue : 300,
+              decimalPrecision : 0,
+              id : 'torrent_delay'
             }
           ]
         });
@@ -226,8 +223,6 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
             for(i=0; i < items.length; i++) {
                 filter_items.push(items[i].data);
             }
-            //TODO: remove this when default filter can't be edited
-            filter_items[filter_items.length-1].filter = ".*";
 
             // build settings object
             var config = {};

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -31,14 +31,12 @@ Copyright:
     statement from all source files in the program, then also delete it here.
 */
 
-// TODO: edit item in grid
-// TODO: make sure default editing is handled correctly
+// TODO: disable editing of default filter cell
 // TODO: load data to grid
 // TODO: save data from grid
 // TODO: make sure stoptime coloumn is rendered as number
 // TODO: add min/max to stop time coloumn
-// TODO: fix layout, grid not expanding
-// TODO: grid drag and drop, http://docs.sencha.com/extjs/4.0.7/#!/example/dd/dnd_grid_to_grid.html
+// TODO: fix layout, grid automatic height
 // TODO: layout, move buttons?
 // TODO: clean up: fix code formatting
 // TODO: clean up: probably lots of unneeded code
@@ -126,11 +124,16 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
                   }
                 },
               },
-              { header : 'Filter', width : .50, dataIndex : 'filter',xtype: 'gridcolumn',},
-              { xtype: 'numbercolumn',
-                header : 'Stop Seed Time (days)',
+              { header : 'Filter',
+                width : .50,
+                dataIndex : 'filter',
+                editor : {xtype : 'textfield' },
+              },
+              { header : 'Stop Seed Time (days)',
                 width : .26,
-                // renderer : Ext.util.Format.number,
+                editor : { xtype : 'numberfield',
+                           maxValue : 365.0,
+                           minValue : 0.01 },
                 dataIndex : 'stoptime'
               },
             ]
@@ -202,10 +205,6 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
 
     onRender: function(ct, position) {
         Deluge.ux.preferences.SeedTimePage.superclass.onRender.call(this, ct, position);
-        this.form.layout = new Ext.layout.FormLayout();
-        this.form.layout.setContainer(this);
-        this.form.doLayout();
-        // this.vbox.doLayout();
     },
 
     onApply: function() {

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -31,17 +31,16 @@ Copyright:
     statement from all source files in the program, then also delete it here.
 */
 
-// TODO: reorder grid
-// TODO: remove item from grid
 // TODO: edit item in grid
-// TODO: make sure default is handled correctly
+// TODO: make sure default editing is handled correctly
 // TODO: load data to grid
 // TODO: save data from grid
-// TODO: fix layout, grid not expanding
-// TODO: layout, move buttons?
-// TODO: add min/max to stop time coloumn
 // TODO: make sure stoptime coloumn is rendered as number
-// TODO: clean up: fix formatting
+// TODO: add min/max to stop time coloumn
+// TODO: fix layout, grid not expanding
+// TODO: grid drag and drop, http://docs.sencha.com/extjs/4.0.7/#!/example/dd/dnd_grid_to_grid.html
+// TODO: layout, move buttons?
+// TODO: clean up: fix code formatting
 // TODO: clean up: probably lots of unneeded code
 
 Ext.ns('Deluge.ux');
@@ -143,6 +142,18 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
           flex: 1,
           viewConfig : {
             forceFit : true,
+              // plugins: {
+              //     ptype: 'Ext.dd.gridviewdragdrop',
+              //     // ptype: 'gridviewdragdrop',
+              //     dragGroup: 'firstGridDDGroup',
+              //     dropGroup: 'firstGridDDGroup'
+              // },
+              // listeners: {
+              //     drop: function(node, data, dropRec, dropPosition) {
+              //         var dropOn = dropRec ? ' ' + dropPosition + ' ' + dropRec.get('name') : ' on empty view';
+              //         console.log("Drag from right to left", 'Dropped ' + data.records[0].get('name') + dropOn);
+              //     }
+              // }
           },
           selModel : new Ext.grid.RowSelectionModel({singleSelect : true}),
         });
@@ -151,7 +162,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
             { field : "label", filter : "a.*sdf", stoptime : 1.5},
             { field : "tracker", filter : "b.*sdf", stoptime : 2.5},
             { field : "label", filter : "c.*sdf", stoptime : 3.5},
-            { field : "label", filter : "c.*sdf", stoptime : 4.5},
+            { field : "label", filter : "d.*sdf", stoptime : 4.5},
             { field : "default", filter : ".*", stoptime : 5.5} ] );
 
         this.filter_list.addButton({text:"Up"},this.filterUp, this);
@@ -166,19 +177,46 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
     },
 
     filterUp: function() {
-        console.log('filterUp');
+        var store = this.filter_list.getStore();
+        var sm = this.filter_list.getSelectionModel();
+        var selected_rec = sm.getSelected();
+        var selected_indx = store.indexOf(selected_rec);
+
+        if (selected_indx > 0 && selected_indx < store.getCount()-1 ) {
+          store.remove(selected_rec);
+          store.insert(selected_indx-1, selected_rec);
+          sm.selectRow(selected_indx-1);
+        }
     },
+
     filterDown: function() {
-        console.log('filterDown');
+        var store = this.filter_list.getStore();
+        var sm = this.filter_list.getSelectionModel();
+        var selected_rec = sm.getSelected();
+        var selected_indx = store.indexOf(selected_rec);
+
+        if (selected_indx < store.getCount()-2 ) {
+          store.remove(selected_rec);
+          store.insert(selected_indx+1, selected_rec);
+          sm.selectRow(selected_indx+1);
+        }
     },
+
     filterAdd: function() {
-        console.log('filterAdd');
         var store = this.filter_list.getStore();
         store.insert(0, new store.recordType({ field : "tracker", filter : ".*", stoptime : 1.0}));
     },
+
     filterRemove: function() {
       var store = this.filter_list.getStore();
-        console.log('filterRemove');
+        var store = this.filter_list.getStore();
+        var sm = this.filter_list.getSelectionModel();
+        var selected_rec = sm.getSelected();
+        var selected_indx = store.indexOf(selected_rec);
+
+        if (selected_indx < store.getCount()-1 ) {
+          store.remove(selected_rec);
+        }
     },
 
     onRender: function(ct, position) {

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -128,7 +128,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
             fields : [
               {name : 'field', type : 'string'},
               {name : 'filter', type : 'string'},
-              {name : 'stoptime', type : 'float'},
+              {name : 'stop_time', type : 'float'},
             ],
             id : 0
           }),
@@ -153,7 +153,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
                 editor : { xtype : 'numberfield',
                            maxValue : 365.0,
                            minValue : 0.01 },
-                dataIndex : 'stoptime'
+                dataIndex : 'stop_time'
               },
             ]
           }),
@@ -201,7 +201,7 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
 
     filterAdd: function() {
         var store = this.filter_list.getStore();
-        store.insert(0, new store.recordType({ field : "label", filter : "RegEx", stoptime : 3.0}));
+        store.insert(0, new store.recordType({ field : "label", filter : "RegEx", stop_time : 3.0}));
     },
 
     filterRemove: function() {
@@ -271,7 +271,7 @@ Deluge.ux.CustomSeedtimeWindow = Ext.extend(Ext.Window, {
             labelWidth: 220,
             items: [{
                     fieldLabel: _('Stop Time (Days)'),
-                    name: 'stoptime',
+                    name: 'stop_time',
                     allowBlank: false,
                     maxValue : 365.0,
                     minValue : 0.01,
@@ -293,7 +293,7 @@ Deluge.ux.CustomSeedtimeWindow = Ext.extend(Ext.Window, {
     },
 
     onOkClick: function() {
-        this.item.stoptime = this.form.getForm().findField('stoptime').getValue();
+        this.item.stop_time = this.form.getForm().findField('stop_time').getValue();
         this.setStoptime(this.item, this.e)
         this.hide();
     },
@@ -305,7 +305,7 @@ Deluge.ux.CustomSeedtimeWindow = Ext.extend(Ext.Window, {
 
     onShow: function(comp) {
         Deluge.ux.CustomSeedtimeWindow.superclass.onShow.call(this, comp);
-        this.form.getForm().findField('stoptime').focus(false, 150);
+        this.form.getForm().findField('stop_time').focus(false, 150);
     }
 });
 
@@ -316,19 +316,19 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
     createMenu: function() {
         menuTimes = [1, 2, 3, 7, 14, 30],
         itemslist = [{  text: _('Never'),
-                        stoptime : -1,
+                        stop_time : -1,
                         handler: this.setStoptime,
                         scope: this
                 }];
         for(indx=0; indx < menuTimes.length; indx++) {
             itemslist.push({  text: _(menuTimes[indx] + ' Days'),
-                        stoptime : menuTimes[indx],
+                        stop_time : menuTimes[indx],
                         handler: this.setStoptime,
                         scope: this
                     });
         }
         itemslist.push({text: _('Custom'),
-                        stoptime : 1,
+                        stop_time : 1,
                         handler: this.setCustomStoptime,
                         scope: this
                         });
@@ -339,13 +339,13 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
         var ids = deluge.torrents.getSelectedIds();
         Ext.each(ids, function(id, i) {
             if (ids.length == i + 1) {
-                deluge.client.seedtime.set_torrent(id, item.stoptime, {
+                deluge.client.seedtime.set_torrent(id, item.stop_time, {
                     success: function() {
                         deluge.ui.update();
                     }
                 });
             } else {
-                deluge.client.seedtime.set_torrent(id, item.stoptime);
+                deluge.client.seedtime.set_torrent(id, item.stop_time);
             }
         });
     },

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -31,7 +31,6 @@ Copyright:
     statement from all source files in the program, then also delete it here.
 */
 
-// TODO: gtk not working?
 // TODO: add same tooltips as gtk
 // TODO: fix perferance page layout, filter list grid automatic height
 // TODO: fix perferance page layout, resize buttons

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -32,7 +32,6 @@ Copyright:
 */
 
 // TODO: return correct field value, (currently always returns tracker)
-// TODO: set seed time columns format to time
 // TODO: disable editing of default filter cell
 // TODO: fix perferance page layout, filter list grid automatic height
 // TODO: fix perferance page layout, resize buttons
@@ -368,10 +367,16 @@ SeedTimePlugin = Ext.extend(Deluge.Plugin, {
             menu: this.torrentMenu
         });
         
+        ftimewithnull = function(n) {
+                if(n==null) {return "";}
+                else {return ftime(n);}
+            };
         // status columns
         this.registerTorrentStatus('seeding_time', _('Seed Time'));
-        this.registerTorrentStatus('seed_stop_time', _('Stop Seed Time'));
-        this.registerTorrentStatus('seed_time_remaining', _('Remaining Seed Time'));
+        this.registerTorrentStatus('seed_stop_time', _('Stop Seed Time'),
+            { colCfg : { sortable : true, renderer : ftimewithnull}});
+        this.registerTorrentStatus('seed_time_remaining', _('Remaining Seed Time'),
+            { colCfg : { sortable : true, renderer : ftimewithnull}});
     }
 });
 Deluge.registerPlugin('SeedTime', SeedTimePlugin);

--- a/seedtime/data/seedtime.js
+++ b/seedtime/data/seedtime.js
@@ -52,8 +52,6 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
             autoHeight: true
         });
 
-        // this.schedule = this.form.add(new Deluge.ux.ScheduleSelector());
-
         this.settings = this.form.add({
           xtype : 'fieldset',
           border : false,
@@ -85,46 +83,104 @@ Deluge.ux.preferences.SeedTimePage = Ext.extend(Ext.Panel, {
         });
 
         this.filter_list = new Ext.grid.GridPanel({
-            store: new Ext.data.ArrayStore({
-                fields: [
-                    {name: 'field', type: 'string'},
-                    {name: 'filter', type: 'string'},
-                    {name: 'stoptime', type: 'float'}
-                ],
-                id: 0
-            }),
-            colModel: new Ext.grid.ColumnModel({
-                defaults: {
-                    sortable: false,
-                    menuDisabled: true
+          store : new Ext.data.JsonStore({
+            fields : [
+              {name : 'field', type : 'string'},
+              {name : 'filter', type : 'string'},
+              {name : 'stoptime', type : 'float'},
+            ],
+            id : 0
+          }),
+          colModel : new Ext.grid.ColumnModel({
+            defaults : {sortable : false, menuDisabled : true},
+            columns : [
+              {
+                header : 'Field',
+                width : .24,
+                sortable : false,
+                dataIndex : 'field',
+                renderer : function(val) {
+                  if (val === "default") {
+                      return 'default';
+                  }
+                  else if (val === "label") {
+                      return '<select><option value="label" selected="selected">label</option><option value="tracker">tracker</option></select>';
+                  }
+                  else {
+                      return '<select><option value="label">label</option><option value="tracker" selected="selected">tracker</option></select>';
+                  }
                 },
-                columns: [{
-                    header: _('Field'),
-                    width: .24,
-                    dataIndex: 'field'
-                }, {
-                    header: _('Filter'),
-                    width: .50,
-                    dataIndex: 'filter'
-                }, {
-                    header: _('Stop Seed Time (days)'),
-                    width: .26,
-                    renderer: Ext.util.Format.number,
-                    dataIndex: 'stoptime'
-                }]
-            }),
-            viewConfig: {
-                forceFit: true,
-            },
-            sm: new Ext.grid.RowSelectionModel({singleSelect:true}),
+              },
+              {header : 'Filter', width : .50, dataIndex : 'filter'},
+              {header : 'Stop Seed Time (days)',
+                width : .26,
+                // renderer : Ext.util.Format.number,
+                dataIndex : 'stoptime'
+              },
+            ]
+          }),
+          flex: 1,
+          viewConfig : {
+            forceFit : true,
+          },
+          sm : new Ext.grid.RowSelectionModel({singleSelect : true}),
         });
 
-        this.add(this.filter_list)
+        this.filter_list.getStore().loadData( [
+            { field : "label", filter : "a.*sdf", stoptime : 5.5},
+            { field : "tracker", filter : "asev", stoptime : 6.5} ] );
+
+        this.add(this.filter_list);
+
+        this.add({
+            xtype: 'container',
+            layout: 'hbox',
+            defaultType: 'button',
+            items: [{
+                itemId: 'up',
+                text: 'Up',
+                scope: this,
+                handler: this.filterUp
+            }, {
+                itemId: 'Down',
+                // margin: '0 0 0 10',
+                text: 'Down',
+                scope: this,
+                handler: this.filterDown
+            }, {
+                itemId: 'add',
+                // margin: '0 0 0 10',
+                text: 'Add',
+                scope: this,
+                handler: this.filterAdd
+            }, {
+                itemId: 'remove',
+                // margin: '0 0 0 10',
+                text: 'Remove',
+                scope: this,
+                handler: this.filterRemove
+            }]
+            });
 
         this.removeWhenStopped = this.settings.items.get("rm_torrent_checkbox");
         this.delayTime = this.settings.items.get("torrent_delay");
-
         this.on('show', this.updateConfig, this);
+    },
+
+    filterUp: function() {
+        console.log('filterUp');
+    },
+    filterDown: function() {
+        console.log('filterDown');
+    },
+    filterAdd: function() {
+        console.log('filterAdd');
+        var store = this.filter_list.getStore();
+        store.add(new store.recordType({ field : "tracker", filter : ".*", stoptime : 1.0}));
+    },
+    filterRemove: function() {
+      var store = this.filter_list.getStore();
+        console.log('filterRemove');
     },
 
     onRender: function(ct, position) {

--- a/seedtime/gtkui.py
+++ b/seedtime/gtkui.py
@@ -162,7 +162,7 @@ class GtkUI(GtkPluginBase):
             "remove_torrent": self.glade.get_widget("chk_remove_torrent").get_active(),
             "filter_list": list({'field': row[0], 'filter': row[1], 'stop_time': row[2]} for row in self.liststore),
             "delay_time": self.glade.get_widget("delay_time").get_value_as_int(),
-            "default_stop_time": self.glade.get_widget("default_stop_time").get_value_as_float(),
+            "default_stop_time": self.glade.get_widget("default_stop_time").get_value(),
         }
         client.seedtime.set_config(config)
 

--- a/seedtime/gtkui.py
+++ b/seedtime/gtkui.py
@@ -161,8 +161,8 @@ class GtkUI(GtkPluginBase):
         config = {
             "remove_torrent": self.glade.get_widget("chk_remove_torrent").get_active(),
             "filter_list": list({'field': row[0], 'filter': row[1], 'stop_time': row[2]} for row in self.liststore),
-            "delay_time": self.glade.get_widget("delay_time").get_value_as_int()
-            "default_stop_time": self.glade.get_widget("default_stop_time").get_value_as_float()
+            "delay_time": self.glade.get_widget("delay_time").get_value_as_int(),
+            "default_stop_time": self.glade.get_widget("default_stop_time").get_value_as_float(),
         }
         client.seedtime.set_config(config)
 
@@ -210,11 +210,9 @@ class GtkUI(GtkPluginBase):
 
         for path in paths:
             itr = model.get_iter(path)
-            if path[0] == 0:
-                return
-            else:
+            if path[0] > 0:
                 previousRow = model.get_iter(path[0]-1)
-            model.move_before(itr, previousRow)
+                model.move_before(itr, previousRow)
 
     def btnDownCallback(self, widget):
         selection = self.treeview.get_selection()
@@ -222,11 +220,9 @@ class GtkUI(GtkPluginBase):
 
         for path in paths:
             itr = model.get_iter(path)
-            if path[0] >= len(model)-1:
-                return
-            else:
+            if path[0] < len(model)-1:
                 nextRow = model.get_iter(path[0]+1)
-            model.move_after(itr, nextRow)
+                model.move_after(itr, nextRow)
 
 class SeedTimeMenu(gtk.MenuItem):
     def __init__(self):

--- a/seedtime/gtkui.py
+++ b/seedtime/gtkui.py
@@ -162,7 +162,8 @@ class GtkUI(GtkPluginBase):
 
         config = {
             "remove_torrent": self.glade.get_widget("chk_remove_torrent").get_active(),
-            "filter_list": list({'field': row[0], 'filter': row[1], 'stop_time': row[2]} for row in self.liststore)
+            "filter_list": list({'field': row[0], 'filter': row[1], 'stop_time': row[2]} for row in self.liststore),
+            "delay_time": self.glade.get_widget("delay_time").get_value_as_int()
         }
         client.seedtime.set_config(config)
 

--- a/seedtime/gtkui.py
+++ b/seedtime/gtkui.py
@@ -174,6 +174,7 @@ class GtkUI(GtkPluginBase):
         """callback for on show_prefs"""
         log.debug('cb get config seedtime')
         self.glade.get_widget("chk_remove_torrent").set_active(config["remove_torrent"])
+        self.glade.get_widget("delay_time").set_value(config["delay_time"])
 
         # populate filter table
         self.liststore = gtk.ListStore(str, str, float)

--- a/seedtime/gtkui.py
+++ b/seedtime/gtkui.py
@@ -44,7 +44,10 @@ from deluge.log import LOG as log
 from deluge.ui.client import client
 from deluge.plugins.pluginbase import GtkPluginBase
 import deluge.component as component
-from deluge.ui.gtkui.listview import cell_data_time
+try:
+    from deluge.ui.gtkui.listview import cell_data_time
+except ImportError:
+    from deluge.ui.gtkui.torrentview_data_funcs import cell_data_time
 
 from common import get_resource
 

--- a/seedtime/gtkui.py
+++ b/seedtime/gtkui.py
@@ -66,10 +66,10 @@ class GtkUI(GtkPluginBase):
         self.seedtime_menu = SeedTimeMenu()
         torrentmenu.append(self.seedtime_menu)
         self.seedtime_menu.show_all()
-        
-        #Build Preference filter table
+
+        # Build Preference filter table
         self.setupFilterTable()
-        
+
     def setupFilterTable(self):
         # Setup filter button callbacks
         self.btnAdd = self.glade.get_widget("btnAdd")
@@ -80,18 +80,19 @@ class GtkUI(GtkPluginBase):
         self.btnUp.connect("clicked", self.btnUpCallback)
         self.btnDown = self.glade.get_widget("btnDown")
         self.btnDown.connect("clicked", self.btnDownCallback)
-        
-        # cell by cell renderer callback, changes field and filter to not editable if the current row is the default filter
+
+        # cell by cell renderer callback, changes field and filter to not editable
+        # if the current row is the default filter
         def rowRendererCb(column, cell, model, itr):
             if model.get_value(itr, 0) == 'default':
                 cell.set_property('editable', False)
             else:
                 cell.set_property('editable', True)
 
-        #creating the treeview,and add columns
+        # creating the treeview,and add columns
         self.treeview = gtk.TreeView()
-        
-        #setup Field column
+
+        # setup Field column
         liststore_field = gtk.ListStore(str)
         for item in ["tracker", "label"]:
             liststore_field.append([item])
@@ -109,8 +110,8 @@ class GtkUI(GtkPluginBase):
         tooltips = Tooltips()
         tooltips.set_tip(label, "Torrent Field to filter.")
         self.treeview.append_column(column)
-        
-        #setup Filter column
+
+        # setup Filter column
         renderer = gtk.CellRendererText()
         renderer.set_property("editable", True)
         renderer.connect("edited", self.on_filter_changed)
@@ -122,8 +123,8 @@ class GtkUI(GtkPluginBase):
         tooltips = Tooltips()
         tooltips.set_tip(label, "RegEx filter to apply to Field")
         self.treeview.append_column(column)
-        
-        #setup stop time column
+
+        # setup stop time column
         renderer = gtk.CellRendererSpin()
         renderer.connect("edited", self.on_stoptime_edited)
         renderer.set_property("editable", True)
@@ -134,13 +135,14 @@ class GtkUI(GtkPluginBase):
         column.set_widget(label)
         label.show()
         tooltips = Tooltips()
-        tooltips.set_tip(label, "Set the amount of time a torrent seeds for before being stopped. Default value is editable")
+        tooltips.set_tip(label, "Set the amount of time a torrent seeds for "
+                                "before being stopped. Default value is editable")
         self.treeview.append_column(column)
 
         self.sw1 = self.glade.get_widget('scrolledwindow1')
-        self.sw1.add(self.treeview)   
-        self.sw1.show_all()     
-        
+        self.sw1.add(self.treeview)
+        self.sw1.show_all()
+
     def disable(self):
         component.get("Preferences").remove_page("SeedTime")
         component.get("PluginManager").deregister_hook("on_apply_prefs", self.on_apply_prefs)
@@ -160,7 +162,7 @@ class GtkUI(GtkPluginBase):
 
         config = {
             "remove_torrent": self.glade.get_widget("chk_remove_torrent").get_active(),
-            "filter_list": list({'field':r[0], 'filter':r[1], 'stop_time':r[2]} for r in self.liststore)
+            "filter_list": list({'field': row[0], 'filter': row[1], 'stop_time': row[2]} for row in self.liststore)
         }
         client.seedtime.set_config(config)
 
@@ -171,12 +173,12 @@ class GtkUI(GtkPluginBase):
         """callback for on show_prefs"""
         log.debug('cb get config seedtime')
         self.glade.get_widget("chk_remove_torrent").set_active(config["remove_torrent"])
-        
+
         # populate filter table
         self.liststore = gtk.ListStore(str, str, float)
         for filter_ref in config['filter_list']:
             self.liststore.append([filter_ref['field'], filter_ref['filter'], filter_ref['stop_time']])
-            
+
         self.treeview.set_model(self.liststore)
 
     def on_field_changed(self, widget, path, text):
@@ -194,7 +196,7 @@ class GtkUI(GtkPluginBase):
     def btnRemoveCallback(self, widget):
         selection = self.treeview.get_selection()
         model, paths = selection.get_selected_rows()
-        
+
         # Get the TreeIter instance for each path
         for path in paths:
             itr = model.get_iter(path)
@@ -204,7 +206,7 @@ class GtkUI(GtkPluginBase):
     def btnUpCallback(self, widget):
         selection = self.treeview.get_selection()
         model, paths = selection.get_selected_rows()
-        
+
         for path in paths:
             itr = model.get_iter(path)
             # Don't move the default filter
@@ -218,7 +220,7 @@ class GtkUI(GtkPluginBase):
     def btnDownCallback(self, widget):
         selection = self.treeview.get_selection()
         model, paths = selection.get_selected_rows()
-        
+
         for path in paths:
             itr = model.get_iter(path)
             # Don't move the default filter

--- a/seedtime/gtkui.py
+++ b/seedtime/gtkui.py
@@ -60,6 +60,7 @@ class GtkUI(GtkPluginBase):
         torrentview = component.get("TorrentView")
         torrentview.add_func_column(_("Seed Time"), cell_data_time, [int], status_field=["seeding_time"])
         torrentview.add_func_column(_("Stop Seed Time"), cell_data_time, [int], status_field=["seed_stop_time"])
+        torrentview.add_func_column(_("Remaining Seed Time"), cell_data_time, [int], status_field=["seed_time_remaining"])
         # Submenu
         log.debug("add items to torrentview-popup menu.")
         torrentmenu = component.get("MenuBar").torrentmenu
@@ -151,6 +152,7 @@ class GtkUI(GtkPluginBase):
             # Columns
             component.get("TorrentView").remove_column(_("Seed Time"))
             component.get("TorrentView").remove_column(_("Stop Seed Time"))
+            component.get("TorrentView").remove_column(_("Remaining Seed Time"))
             # Submenu
             torrentmenu = component.get("MenuBar").torrentmenu
             torrentmenu.remove(self.seedtime_menu)

--- a/seedtime/webui.py
+++ b/seedtime/webui.py
@@ -37,19 +37,15 @@
 #    statement from all source files in the program, then also delete it here.
 #
 
-from deluge.log import LOG as log
-from deluge.ui.client import client
-from deluge import component
+import logging
+
 from deluge.plugins.pluginbase import WebPluginBase
 
 from common import get_resource
 
+log = logging.getLogger(__name__)
+
 class WebUI(WebPluginBase):
 
     scripts = [get_resource("seedtime.js")]
-
-    def enable(self):
-        pass
-
-    def disable(self):
-        pass
+    debug_scripts = scripts

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools import setup
 __plugin_name__ = "SeedTime"
 __author__ = "Chase Sterling"
 __author_email__ = "chase.sterling@gmail.com"
-__version__ = "0.6"
+__version__ = "0.7.0"
 __url__ = ""
 __license__ = "GPLv3"
 __description__ = "Automatically pause or remove torrents after specified amount of seeding."

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools import setup
 __plugin_name__ = "SeedTime"
 __author__ = "Chase Sterling"
 __author_email__ = "chase.sterling@gmail.com"
-__version__ = "0.5"
+__version__ = "0.6"
 __url__ = ""
 __license__ = "GPLv3"
 __description__ = "Automatically pause or remove torrents after specified amount of seeding."

--- a/setup.py
+++ b/setup.py
@@ -37,17 +37,19 @@
 #    statement from all source files in the program, then also delete it here.
 #
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 __plugin_name__ = "SeedTime"
 __author__ = "Chase Sterling"
 __author_email__ = "chase.sterling@gmail.com"
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __url__ = ""
 __license__ = "GPLv3"
-__description__ = "Automatically pause or remove torrents after specified amount of seeding."
+__description__ = (
+    "Automatically pause or remove torrents after specified amount of seeding."
+)
 __long_description__ = """"""
-__pkg_data__ = {__plugin_name__.lower(): ["template/*", "data/*"]}
+__pkg_data__ = {"deluge_" + __plugin_name__.lower(): ["data/*"]}
 
 setup(
     name=__plugin_name__,
@@ -58,16 +60,17 @@ setup(
     url=__url__,
     license=__license__,
     long_description=__long_description__ if __long_description__ else __description__,
-
-    packages=[__plugin_name__.lower()],
-    package_data = __pkg_data__,
-
+    packages=find_packages(),
+    package_data=__pkg_data__,
     entry_points="""
     [deluge.plugin.core]
-    %s = %s:CorePlugin
+    %s = deluge_%s:CorePlugin
     [deluge.plugin.gtkui]
     %s = %s:GtkUIPlugin
+    [deluge.plugin.gtk3ui]
+    %s = deluge_%s:Gtk3UIPlugin
     [deluge.plugin.web]
-    %s = %s:WebUIPlugin
-    """ % ((__plugin_name__, __plugin_name__.lower())*3)
+    %s = deluge_%s:WebUIPlugin
+    """
+    % ((__plugin_name__, __plugin_name__.lower()) * 4),
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools import setup
 __plugin_name__ = "SeedTime"
 __author__ = "Chase Sterling"
 __author_email__ = "chase.sterling@gmail.com"
-__version__ = "0.7.0"
+__version__ = "2.0.0"
 __url__ = ""
 __license__ = "GPLv3"
 __description__ = "Automatically pause or remove torrents after specified amount of seeding."


### PR DESCRIPTION
I added a support for setting the initial seedtime limit based on tracker or label. The user can set up a table of regex filters in the gtkui.

![preferencesscreen](https://cloud.githubusercontent.com/assets/8310169/6694328/f789d5e6-ccaf-11e4-9bf8-a8e759554453.PNG)

I would have liked to add all filter code to post_torrent_add hook, but I could not see a way to guarantee that the label post_torrent_add hook would be processed first. So instead I deferred the call by 1 second.

Suggestions welcome
